### PR TITLE
Add extract-key command

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Mobile Verification Toolkit (MVT) is a collection of utilities to simplify and a
 
 It has been developed and released by the [Amnesty International Security Lab](https://www.amnesty.org/en/tech/) in July 2021 in the context of the [Pegasus project](https://forbiddenstories.org/about-the-pegasus-project/) along with [a technical forensic methodology and forensic evidences](https://www.amnesty.org/en/latest/research/2021/07/forensic-methodology-report-how-to-catch-nso-groups-pegasus/).
 
-*Warning*: this tool has been released as a forensic tool for a technical audience. Using it requires some technical skills such as understanding basics of forensic analysis and using command line tools.
+_Warning_: this tool has been released as a forensic tool for a technical audience. Using it requires some technical skills such as understanding basics of forensic analysis and using command line tools.
 
 [Please check out the documentation.](https://mvt.readthedocs.io/en/latest/)
 
@@ -19,6 +19,7 @@ It has been developed and released by the [Amnesty International Security Lab](h
 First you need to install dependencies, on Linux `sudo apt install python3 python3-pip libusb-1.0-0` or on MacOS `brew install python3 libusb`.
 
 Then you can install mvt from pypi with `pip3 install mvt`, or directly from sources:
+
 ```bash
 git clone https://github.com/mvt-project/mvt.git
 cd mvt
@@ -29,21 +30,22 @@ pip3 install .
 
 MVT provides two commands `mvt-ios` and `mvt-android` with the following subcommands available:
 
-* `mvt-ios`:
-    * `check-backup`: Extract artifacts from an iTunes backup
-    * `check-fs`: Extract artifacts from a full filesystem dump
-    * `check-iocs`: Compare stored JSON results to provided indicators
-    * `decrypt-backup`:  Decrypt an encrypted iTunes backup
-* `mvt-android`:
-    * `check-backup`: Check an Android Backup
-    * `download-apks`: Download all or non-safelisted installed APKs
+- `mvt-ios`:
+  - `check-backup`: Extract artifacts from an iTunes backup
+  - `check-fs`: Extract artifacts from a full filesystem dump
+  - `check-iocs`: Compare stored JSON results to provided indicators
+  - `decrypt-backup`: Decrypt an encrypted iTunes backup
+  - `extract-key`: Extract decryption key from an iTunes backup
+- `mvt-android`:
+  - `check-backup`: Check an Android Backup
+  - `download-apks`: Download all or non-safelisted installed APKs
 
 Check out [the documentation to see how to use them](https://mvt.readthedocs.io/en/latest/).
 
 ## License
 
-The purpose of MVT is to facilitate the ***consensual forensic analysis*** of devices of those who might be targets of sophisticated mobile spyware attacks, especially members of civil society and marginalized communities. We do not want MVT to enable privacy violations of non-consenting individuals. Therefore, the goal of this license is to prohibit the use of MVT (and any other software licensed the same) for the purpose of *adversarial forensics*.
+The purpose of MVT is to facilitate the **_consensual forensic analysis_** of devices of those who might be targets of sophisticated mobile spyware attacks, especially members of civil society and marginalized communities. We do not want MVT to enable privacy violations of non-consenting individuals. Therefore, the goal of this license is to prohibit the use of MVT (and any other software licensed the same) for the purpose of _adversarial forensics_.
 
-In order to achieve this, MVT is released under an adaptation of [Mozilla Public License v2.0](https://www.mozilla.org/MPL). This modified license includes a new clause 3.0, "Consensual Use Restriction" which permits the use of the licensed software (and any *"Larger Work"* derived from it) exclusively with the explicit consent of the person/s whose data is being extracted and/or analysed (*"Data Owner"*).
+In order to achieve this, MVT is released under an adaptation of [Mozilla Public License v2.0](https://www.mozilla.org/MPL). This modified license includes a new clause 3.0, "Consensual Use Restriction" which permits the use of the licensed software (and any _"Larger Work"_ derived from it) exclusively with the explicit consent of the person/s whose data is being extracted and/or analysed (_"Data Owner"_).
 
 [Read the LICENSE](https://github.com/mvt-project/mvt/blob/main/LICENSE)

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Mobile Verification Toolkit (MVT) is a collection of utilities to simplify and a
 
 It has been developed and released by the [Amnesty International Security Lab](https://www.amnesty.org/en/tech/) in July 2021 in the context of the [Pegasus project](https://forbiddenstories.org/about-the-pegasus-project/) along with [a technical forensic methodology and forensic evidences](https://www.amnesty.org/en/latest/research/2021/07/forensic-methodology-report-how-to-catch-nso-groups-pegasus/).
 
-*Warning*: this tool has been released as a forensic tool for a technical audience. Using it requires some technical skills such as understanding basics of forensic analysis and using command line tools.
+_Warning_: this tool has been released as a forensic tool for a technical audience. Using it requires some technical skills such as understanding basics of forensic analysis and using command line tools.
 
 [Please check out the documentation.](https://mvt.readthedocs.io/en/latest/)
 
@@ -19,6 +19,7 @@ It has been developed and released by the [Amnesty International Security Lab](h
 First you need to install dependencies, on Linux `sudo apt install python3 python3-pip libusb-1.0-0` or on MacOS `brew install python3 libusb`.
 
 Then you can install mvt from pypi with `pip3 install mvt`, or directly from sources:
+
 ```bash
 git clone https://github.com/mvt-project/mvt.git
 cd mvt
@@ -29,21 +30,23 @@ pip3 install .
 
 MVT provides two commands `mvt-ios` and `mvt-android` with the following subcommands available:
 
-* `mvt-ios`:
-    * `check-backup`: Extract artifacts from an iTunes backup
-    * `check-fs`: Extract artifacts from a full filesystem dump
-    * `check-iocs`: Compare stored JSON results to provided indicators
-    * `decrypt-backup`:  Decrypt an encrypted iTunes backup
-* `mvt-android`:
-    * `check-backup`: Check an Android Backup
-    * `download-apks`: Download all or non-safelisted installed APKs
+- `mvt-ios`:
+  - `check-backup`: Extract artifacts from an iTunes backup
+  - `check-fs`: Extract artifacts from a full filesystem dump
+  - `check-iocs`: Compare stored JSON results to provided indicators
+  - `decrypt-backup`: Decrypt an encrypted iTunes backup
+- `mvt-android`:
+  - `check-backup`: Check an Android Backup
+  - `download-apks`: Download all or non-safelisted installed APKs
 
 Check out [the documentation to see how to use them](https://mvt.readthedocs.io/en/latest/).
 
+Amnesty International maintains IOCs, _including indicators for NSO Group Pegasus_, in the [investigations repository](https://github.com/AmnestyTech/investigations)
+
 ## License
 
-The purpose of MVT is to facilitate the ***consensual forensic analysis*** of devices of those who might be targets of sophisticated mobile spyware attacks, especially members of civil society and marginalized communities. We do not want MVT to enable privacy violations of non-consenting individuals. Therefore, the goal of this license is to prohibit the use of MVT (and any other software licensed the same) for the purpose of *adversarial forensics*.
+The purpose of MVT is to facilitate the **_consensual forensic analysis_** of devices of those who might be targets of sophisticated mobile spyware attacks, especially members of civil society and marginalized communities. We do not want MVT to enable privacy violations of non-consenting individuals. Therefore, the goal of this license is to prohibit the use of MVT (and any other software licensed the same) for the purpose of _adversarial forensics_.
 
-In order to achieve this, MVT is released under an adaptation of [Mozilla Public License v2.0](https://www.mozilla.org/MPL). This modified license includes a new clause 3.0, "Consensual Use Restriction" which permits the use of the licensed software (and any *"Larger Work"* derived from it) exclusively with the explicit consent of the person/s whose data is being extracted and/or analysed (*"Data Owner"*).
+In order to achieve this, MVT is released under an adaptation of [Mozilla Public License v2.0](https://www.mozilla.org/MPL). This modified license includes a new clause 3.0, "Consensual Use Restriction" which permits the use of the licensed software (and any _"Larger Work"_ derived from it) exclusively with the explicit consent of the person/s whose data is being extracted and/or analysed (_"Data Owner"_).
 
 [Read the LICENSE](https://github.com/mvt-project/mvt/blob/main/LICENSE)

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Mobile Verification Toolkit (MVT) is a collection of utilities to simplify and a
 
 It has been developed and released by the [Amnesty International Security Lab](https://www.amnesty.org/en/tech/) in July 2021 in the context of the [Pegasus project](https://forbiddenstories.org/about-the-pegasus-project/) along with [a technical forensic methodology and forensic evidences](https://www.amnesty.org/en/latest/research/2021/07/forensic-methodology-report-how-to-catch-nso-groups-pegasus/).
 
-_Warning_: this tool has been released as a forensic tool for a technical audience. Using it requires some technical skills such as understanding basics of forensic analysis and using command line tools.
+*Warning*: this tool has been released as a forensic tool for a technical audience. Using it requires some technical skills such as understanding basics of forensic analysis and using command line tools.
 
 [Please check out the documentation.](https://mvt.readthedocs.io/en/latest/)
 
@@ -19,7 +19,6 @@ _Warning_: this tool has been released as a forensic tool for a technical audien
 First you need to install dependencies, on Linux `sudo apt install python3 python3-pip libusb-1.0-0` or on MacOS `brew install python3 libusb`.
 
 Then you can install mvt from pypi with `pip3 install mvt`, or directly from sources:
-
 ```bash
 git clone https://github.com/mvt-project/mvt.git
 cd mvt
@@ -30,23 +29,21 @@ pip3 install .
 
 MVT provides two commands `mvt-ios` and `mvt-android` with the following subcommands available:
 
-- `mvt-ios`:
-  - `check-backup`: Extract artifacts from an iTunes backup
-  - `check-fs`: Extract artifacts from a full filesystem dump
-  - `check-iocs`: Compare stored JSON results to provided indicators
-  - `decrypt-backup`: Decrypt an encrypted iTunes backup
-- `mvt-android`:
-  - `check-backup`: Check an Android Backup
-  - `download-apks`: Download all or non-safelisted installed APKs
+* `mvt-ios`:
+    * `check-backup`: Extract artifacts from an iTunes backup
+    * `check-fs`: Extract artifacts from a full filesystem dump
+    * `check-iocs`: Compare stored JSON results to provided indicators
+    * `decrypt-backup`:  Decrypt an encrypted iTunes backup
+* `mvt-android`:
+    * `check-backup`: Check an Android Backup
+    * `download-apks`: Download all or non-safelisted installed APKs
 
 Check out [the documentation to see how to use them](https://mvt.readthedocs.io/en/latest/).
 
-Amnesty International maintains IOCs, _including indicators for NSO Group Pegasus_, in the [investigations repository](https://github.com/AmnestyTech/investigations)
-
 ## License
 
-The purpose of MVT is to facilitate the **_consensual forensic analysis_** of devices of those who might be targets of sophisticated mobile spyware attacks, especially members of civil society and marginalized communities. We do not want MVT to enable privacy violations of non-consenting individuals. Therefore, the goal of this license is to prohibit the use of MVT (and any other software licensed the same) for the purpose of _adversarial forensics_.
+The purpose of MVT is to facilitate the ***consensual forensic analysis*** of devices of those who might be targets of sophisticated mobile spyware attacks, especially members of civil society and marginalized communities. We do not want MVT to enable privacy violations of non-consenting individuals. Therefore, the goal of this license is to prohibit the use of MVT (and any other software licensed the same) for the purpose of *adversarial forensics*.
 
-In order to achieve this, MVT is released under an adaptation of [Mozilla Public License v2.0](https://www.mozilla.org/MPL). This modified license includes a new clause 3.0, "Consensual Use Restriction" which permits the use of the licensed software (and any _"Larger Work"_ derived from it) exclusively with the explicit consent of the person/s whose data is being extracted and/or analysed (_"Data Owner"_).
+In order to achieve this, MVT is released under an adaptation of [Mozilla Public License v2.0](https://www.mozilla.org/MPL). This modified license includes a new clause 3.0, "Consensual Use Restriction" which permits the use of the licensed software (and any *"Larger Work"* derived from it) exclusively with the explicit consent of the person/s whose data is being extracted and/or analysed (*"Data Owner"*).
 
 [Read the LICENSE](https://github.com/mvt-project/mvt/blob/main/LICENSE)

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ It has been developed and released by the [Amnesty International Security Lab](h
 
 First you need to install dependencies, on Linux `sudo apt install python3 python3-pip libusb-1.0-0` or on MacOS `brew install python3 libusb`.
 
-Then you can install mvt from pypi with `pip3 install mvt`, or directly form sources:
+Then you can install mvt from pypi with `pip3 install mvt`, or directly from sources:
 ```bash
 git clone https://github.com/mvt-project/mvt.git
 cd mvt

--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ Mobile Verification Toolkit (MVT) is a collection of utilities to simplify and a
 
 It has been developed and released by the [Amnesty International Security Lab](https://www.amnesty.org/en/tech/) in July 2021 in the context of the [Pegasus project](https://forbiddenstories.org/about-the-pegasus-project/) along with [a technical forensic methodology and forensic evidences](https://www.amnesty.org/en/latest/research/2021/07/forensic-methodology-report-how-to-catch-nso-groups-pegasus/).
 
+*Warning*: this tool has been released as a forensic tool for a technical audience. Using it requires some technical skills such as understanding basics of forensic analysis and using command line tools.
+
 [Please check out the documentation.](https://mvt.readthedocs.io/en/latest/)
 
 ## Installation

--- a/mvt/common/module.py
+++ b/mvt/common/module.py
@@ -3,6 +3,7 @@
 # See the file 'LICENSE' for usage and copying permissions, or find a copy at
 #   https://github.com/mvt-project/mvt/blob/main/LICENSE
 
+import io
 import os
 import re
 import csv
@@ -160,7 +161,7 @@ def save_timeline(timeline, timeline_path):
     :param timeline: List of records to order and store.
     :param timeline_path: Path to the csv file to store the timeline to.
     """
-    with open(timeline_path, "a+") as handle:
+    with io.open(timeline_path, "a+", encoding="utf-8") as handle:
         csvoutput = csv.writer(handle, delimiter=",", quotechar="\"")
         csvoutput.writerow(["UTC Timestamp", "Plugin", "Event", "Description"])
         for event in sorted(timeline, key=lambda x: x["timestamp"] if x["timestamp"] is not None else ""):

--- a/mvt/ios/cli.py
+++ b/mvt/ios/cli.py
@@ -15,6 +15,7 @@ from mvt.common.options import MutuallyExclusiveOption
 from mvt.common.indicators import Indicators
 
 from .decrypt import DecryptBackup
+from .keyutils import KeyUtils
 from .modules.fs import BACKUP_MODULES, FS_MODULES
 
 # Setup logging using Rich.
@@ -59,6 +60,26 @@ def decrypt_backup(destination, password, key_file, backup_path):
     else:
         raise click.ClickException("Missing required option. Specify either "
                                    "--password or --key-file.")
+
+#==============================================================================
+# Command: extract-key
+#==============================================================================
+@cli.command("extract-key", help="Extract decryption key from an iTunes backup")
+@click.option("--password", "-p",
+              help="Password to use to decrypt the backup",
+              prompt="Backup password", 
+              hide_input=True, prompt_required=False, required=True)
+@click.option("--key-file", "-k",
+              help="Key file to be written (if unset, will print to STDOUT)",
+              required=False,
+              type=click.Path(exists=False, file_okay=True, dir_okay=False, writable=True))
+@click.argument("BACKUP_PATH", type=click.Path(exists=True))
+def extract_key(password, backup_path, key_file):
+    key_utils = KeyUtils(password, backup_path)
+    if key_file:
+        key_utils.write_key(key_file)
+    else:
+        key_utils.print_key()
 
 
 #==============================================================================

--- a/mvt/ios/keyutils.py
+++ b/mvt/ios/keyutils.py
@@ -1,0 +1,52 @@
+import os
+import logging
+from iOSbackup import iOSbackup
+
+log = logging.getLogger(__name__)
+
+class KeyUtils:
+    """This class provides functions to extract a backup key from a password.
+    """
+
+    def __init__(self, password, backup_path):
+        """Generates a key file for an iOS backup.
+        :param password: Backup encryption password
+        :param key_file: Path to the file where to store the generated key file
+        """
+        self.password = password
+        self.backup_path = backup_path
+        self._backup = None
+
+    def get_key(self):
+        try:
+            self._backup = iOSbackup(udid=os.path.basename(self.backup_path),
+                                     cleartextpassword=self.password,
+                                     backuproot=os.path.dirname(self.backup_path))
+        except Exception as e:
+            log.exception(e)
+            log.critical("Failed to decrypt backup. Did you provide the correct password?")
+            return
+        else:
+            self.decryption_key = self._backup.getDecryptionKey()
+            log.info("Extracted decryption key.")
+
+    def print_key(self):
+        self.get_key()
+        log.info("Decryption key for backup at path %s is:\n %s",
+                 self.backup_path, self.decryption_key)
+    
+    def write_key(self, key_file):
+        self.get_key()
+        
+        try:
+            with open(key_file, 'w') as writer:
+                writer.write(self.decryption_key)
+        except Exception as e:
+            log.exception(e)
+            log.critical("Failed to write key file.")
+            return
+        else:
+            log.info("Wrote decryption key for backup at path %s to %s",
+                     self.backup_path, key_file)
+            log.warn("%s is equivalent to a stored plaintext password. Keep this file safe!",
+                     key_file)

--- a/mvt/ios/keyutils.py
+++ b/mvt/ios/keyutils.py
@@ -46,7 +46,7 @@ class KeyUtils:
             log.critical("Failed to write key file.")
             return
         else:
-            log.info("Wrote decryption key for backup at path %s to %s",
+            log.info("Wrote decryption key for backup at path %s to file %s",
                      self.backup_path, key_file)
-            log.warn("%s is equivalent to a stored plaintext password. Keep this file safe!",
+            log.warn("The file %s is equivalent to a plaintext password. Keep this file safe!",
                      key_file)

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ with open(readme_path, encoding="utf-8") as handle:
 
 requires = (
     # Base dependencies:
-    "click",
+    "click >= 8.0.1",
     "rich",
     "tld",
     "tqdm",


### PR DESCRIPTION
The ``extract-key`` command allows extracting decryption keys from backups. 
Keys can be written to a file for use with ``decrypt-backup -k``, or printed to STDOUT for use with ``decrypt-backup -p``