### PR TITLE
Better check for if device has root

### DIFF
--- a/mvt/android/modules/adb/base.py
+++ b/mvt/android/modules/adb/base.py
@@ -96,7 +96,7 @@ class AndroidExtraction(MVTModule):
         """Check if we have a `su` binary on the Android device.
         :returns: Boolean indicating whether a `su` binary is present or not
         """
-        return bool(self._adb_command("[ ! -f /sbin/su ] || echo 1"))
+        return bool(self._adb_command("which su"))
 
     def _adb_root_or_die(self):
         """Check if we have a `su` binary, otherwise raise an Exception.

--- a/mvt/android/modules/adb/base.py
+++ b/mvt/android/modules/adb/base.py
@@ -96,7 +96,7 @@ class AndroidExtraction(MVTModule):
         """Check if we have a `su` binary on the Android device.
         :returns: Boolean indicating whether a `su` binary is present or not
         """
-        return bool(self._adb_command("which su"))
+        return bool(self._adb_command("command -v su"))
 
     def _adb_root_or_die(self):
         """Check if we have a `su` binary, otherwise raise an Exception.


### PR DESCRIPTION
"which su" will return the path of the su binary, or it will return nothing. 
The python boolean of a string with something in it (such as the path of the su binary), will be True.
An empty string (where there is no su binary) will be False.

This fixes Issue #9 