### PR TITLE
Fix download of APKs that require root privileges

### DIFF
--- a/mvt/android/download_apks.py
+++ b/mvt/android/download_apks.py
@@ -135,7 +135,7 @@ class DownloadAPKs(AndroidExtraction):
         try:
             with PullProgress(unit='B', unit_divisor=1024, unit_scale=True,
                               miniters=1) as pp:
-                self._adb_download(remote_path, local_path,
+                self._adb_download(remote_path, local_path, package_name,
                                    progress_callback=pp.update_to)
         except Exception as e:
             log.exception("Failed to pull package file from %s: %s",


### PR DESCRIPTION
Some system APKs are stored in directories that require root privileges, such as /system/product.