### PR TITLE
[iOS CLI] Remove non-existent SYSDIAGNOSE_MODULES reference

### DIFF
--- a/mvt/ios/cli.py
+++ b/mvt/ios/cli.py
@@ -172,7 +172,7 @@ def check_fs(iocs, output, fast, dump_path, list_modules, module):
 @click.argument("FOLDER", type=click.Path(exists=True))
 def check_iocs(iocs, list_modules, module, folder):
     all_modules = []
-    for entry in BACKUP_MODULES + FS_MODULES + SYSDIAGNOSE_MODULES:
+    for entry in BACKUP_MODULES + FS_MODULES:
         if entry not in all_modules:
             all_modules.append(entry)
 


### PR DESCRIPTION
SYSDIAGNOSE_MODULES is not present nor is it referenced elsewhere.  I assume this is a dangling reference to something that was removed?

It's causing a NamError exception when running check-iocs via the iOS CLI.