### PR TITLE
Fixes package extraction without uid

### DIFF
--- a/mvt/android/modules/adb/packages.py
+++ b/mvt/android/modules/adb/packages.py
@@ -64,6 +64,9 @@ class Packages(AndroidExtraction):
                 continue
 
             fields = line.split()
+            if len(fields) < 3:
+                continue
+
             file_name, package_name = fields[0].split(":")[1].rsplit("=", 1)
             installer = fields[1].split("=")[1].strip()
             if installer == "null":


### PR DESCRIPTION
When I tried running `mvt-android check-adb` I got following error during package extraction:
```
14:15:29 ERROR    [mvt.android.modules.adb.packages] Error in running extraction from module Packages: list index out of range
                  Traceback (most recent call last):                                                                          
                    File "/usr/lib/python3.9/site-packages/mvt/common/module.py", line 134, in run_module                     
                      module.run()                                                                                            
                    File "/usr/lib/python3.9/site-packages/mvt/android/modules/adb/packages.py", line 71, in run              
                      uid = fields[2].split(":")[1].strip()                                                                   
                  IndexError: list index out of range
```
So I looked into the code and added a quick fix for it. I assume this is only a problem when a package does not provide a UID. If this should handled differently please let me know.