### PR TITLE
[ADB] Fix WhatsApp database parsing (thumb_image)

### DIFF
--- a/mvt/android/modules/adb/whatsapp.py
+++ b/mvt/android/modules/adb/whatsapp.py
@@ -6,6 +6,7 @@
 import os
 import sqlite3
 import logging
+import base64
 
 from .base import AndroidExtraction
 from mvt.common.utils import convert_timestamp_to_iso, check_for_links
@@ -69,6 +70,8 @@ class Whatsapp(AndroidExtraction):
 
             # If we find links in the messages or if they are empty we add them to the list.
             if check_for_links(message["data"]) or message["data"].strip() == "":
+                if (message.get('thumb_image') is not None):
+                    message['thumb_image'] = base64.b64encode(message['thumb_image'])
                 messages.append(message)
 
         cur.close()

--- a/mvt/common/module.py
+++ b/mvt/common/module.py
@@ -89,7 +89,10 @@ class MVTModule(object):
             results_file_name = f"{name}.json"
             results_json_path = os.path.join(self.output_folder, results_file_name)
             with open(results_json_path, "w") as handle:
-                json.dump(self.results, handle, indent=4)
+                try:
+                    json.dump(self.results, handle, indent=4)
+                except Exception as e:
+                    self.log.error(e)
 
         if self.detected:
             detected_file_name = f"{name}_detected.json"


### PR DESCRIPTION
When using WhatsApp module, parsing WhatsApp database will fail if one message contains a link and a thumb image : 

```bash
$ mvt-android check-adb  -m Whatsapp -o out
14:18:16 INFO     [mvt.android.cli] Checking Android through adb bridge                                                                                                                                                                    
         INFO     [mvt.android.modules.adb.whatsapp] Running module Whatsapp...                                                                                                                                                            
         INFO     [mvt.android.modules.adb.whatsapp] Extracted a total of 92 WhatsApp messages containing links                                                                                                                            
Traceback (most recent call last):
  File "/home/me/.local/bin/mvt-android", line 8, in <module>
    sys.exit(cli())
  File "/home/me/.local/lib/python3.9/site-packages/click/core.py", line 1137, in __call__
    return self.main(*args, **kwargs)
  File "/home/me/.local/lib/python3.9/site-packages/click/core.py", line 1062, in main
    rv = self.invoke(ctx)
  File "/home/me/.local/lib/python3.9/site-packages/click/core.py", line 1668, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/me/.local/lib/python3.9/site-packages/click/core.py", line 1404, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/me/.local/lib/python3.9/site-packages/click/core.py", line 763, in invoke
    return __callback(*args, **kwargs)
  File "/home/me/.local/lib/python3.9/site-packages/mvt/android/cli.py", line 115, in check_adb
    run_module(m)
  File "/home/me/.local/lib/python3.9/site-packages/mvt/common/module.py", line 165, in run_module
    module.save_to_json()
  File "/home/me/.local/lib/python3.9/site-packages/mvt/common/module.py", line 92, in save_to_json
    json.dump(self.results, handle, indent=4)
  File "/home/me/.local/lib/python3.9/site-packages/simplejson/__init__.py", line 290, in dump
    for chunk in iterable:
  File "/home/me/.local/lib/python3.9/site-packages/simplejson/encoder.py", line 684, in _iterencode
    for chunk in _iterencode_list(o, _current_indent_level):
  File "/home/me/.local/lib/python3.9/site-packages/simplejson/encoder.py", line 531, in _iterencode_list
    for chunk in chunks:
  File "/home/me/.local/lib/python3.9/site-packages/simplejson/encoder.py", line 620, in _iterencode_dict
    yield _encoder(value)
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xac in position 0: invalid start byte
```

This is due to message having the following format : 

```
{
    '_id': '[REDACTED]',
    'key_remote_jid': '[REDACTED]',
    'key_from_me': 0,
    'key_id': '[REDACTED]',
    'status': 0,
    'needs_push': 0,
    'data': '[REDACTED]',
    'timestamp': [REDACTED],
    'media_url': '[REDACTED]',
    'media_mime_type': None,
    'media_wa_type': '0',
    'media_size': 0,
    'media_name': '[REDACTED]',
    'media_hash': None,
    [...]
    'thumb_image': b'\xac\xed\x00\x05ur\x00\x02[B\xac\xf3\x17\xf8\x06\x08T\xe0\x02\x00\x00xp\x00\x00\x00\x00',
    [...],
    'isodate': None
}
```

`thumb_image` is a binary object, which can't be `json.dump`-ed

My fix is to encode `thumb_image` in base64, if that attribute exists.

Because of the actual code structure, before the fix, the parsing of the whole WhatsApp database would stop at the first `thumb_image` encountered.

This is also fixed by catching the Exception in `mvt/common/module.py`