### PR TITLE
[ADB] Handle SMS base in mmssms.db instead of bugle_db

### DIFF
--- a/mvt/android/modules/adb/base.py
+++ b/mvt/android/modules/adb/base.py
@@ -112,6 +112,19 @@ class AndroidExtraction(MVTModule):
         :returns: Output of command
         """
         return self._adb_command(f"su -c {command}")
+    
+    def _adb_check_file_exists(self, file):
+        """Verify that a file exists.
+        :param file: Path of the file
+        :returns: Boolean indicating whether the file exists or not
+        """
+
+        # Connect to the device over adb.
+        self._adb_connect()
+        # Check if we have root, if not raise an Exception.
+        self._adb_root_or_die()
+        
+        return bool(self._adb_command_as_root(f"[ ! -f {file} ] || echo 1"))
 
     def _adb_download(self, remote_path, local_path, progress_callback=None, retry_root=True):
         """Download a file form the device.

--- a/mvt/android/modules/adb/sms.py
+++ b/mvt/android/modules/adb/sms.py
@@ -70,7 +70,6 @@ class SMS(AndroidExtraction):
     def _parse_db(self, db_path):
         """Parse an Android bugle_db SMS database file.
         :param db_path: Path to the Android SMS database file to process
-        :param sql_command: SQL command to execute
         """
         conn = sqlite3.connect(db_path)
         cur = conn.cursor()

--- a/mvt/android/modules/adb/sms.py
+++ b/mvt/android/modules/adb/sms.py
@@ -13,6 +13,29 @@ from mvt.common.utils import convert_timestamp_to_iso, check_for_links
 log = logging.getLogger(__name__)
 
 SMS_PATH = "data/data/com.google.android.apps.messaging/databases/bugle_db"
+SMS_PATH_2 = "data/data/com.android.providers.telephony/databases/mmssms.db"
+sql_command_1 = """
+SELECT 
+    ppl.normalized_destination AS number,
+    p.timestamp AS timestamp,
+CASE WHEN m.sender_id IN 
+(SELECT _id FROM participants WHERE contact_id=-1)
+THEN 2 ELSE 1 END incoming, p.text AS text 
+FROM messages m, conversations c, parts p,
+        participants ppl, conversation_participants cp
+WHERE (m.conversation_id = c._id)
+    AND (m._id = p.message_id)
+    AND (cp.conversation_id = c._id)
+    AND (cp.participant_id = ppl._id);
+"""
+sql_command_2 = """
+SELECT 
+    address AS number,
+    date_sent AS timestamp,
+    type as incoming,
+    body AS text 
+FROM sms;
+"""
 
 class SMS(AndroidExtraction):
     """This module extracts all SMS messages containing links."""
@@ -47,23 +70,16 @@ class SMS(AndroidExtraction):
     def _parse_db(self, db_path):
         """Parse an Android bugle_db SMS database file.
         :param db_path: Path to the Android SMS database file to process
+        :param sql_command: SQL command to execute
         """
         conn = sqlite3.connect(db_path)
         cur = conn.cursor()
-        cur.execute("""
-            SELECT 
-                ppl.normalized_destination AS number,
-                p.timestamp AS timestamp,
-            CASE WHEN m.sender_id IN 
-            (SELECT _id FROM participants WHERE contact_id=-1)
-            THEN 2 ELSE 1 END incoming, p.text AS text 
-            FROM messages m, conversations c, parts p,
-                 participants ppl, conversation_participants cp
-            WHERE (m.conversation_id = c._id)
-                AND (m._id = p.message_id)
-                AND (cp.conversation_id = c._id)
-                AND (cp.participant_id = ppl._id);
-        """)
+        
+        if (self.SMS_DB_TYPE == 1):
+            cur.execute(sql_command_1)
+        elif (self.SMS_DB_TYPE == 2):
+            cur.execute(sql_command_2)
+
         names = [description[0] for description in cur.description]
 
         for item in cur:
@@ -85,7 +101,15 @@ class SMS(AndroidExtraction):
         log.info("Extracted a total of %d SMS messages containing links", len(self.results))
 
     def run(self):
+        # Checking the SMS database path
         try:
-            self._adb_process_file(os.path.join("/", SMS_PATH), self._parse_db)
+            if (self._adb_check_file_exists(os.path.join("/", SMS_PATH))):
+                self.SMS_DB_TYPE = 1
+                self._adb_process_file(os.path.join("/", SMS_PATH), self._parse_db)
+            elif (self._adb_check_file_exists(os.path.join("/", SMS_PATH_2))):
+                self.SMS_DB_TYPE = 2
+                self._adb_process_file(os.path.join("/", SMS_PATH_2), self._parse_db)
+            else:
+                self.log.error("No SMS database found")
         except Exception as e:
             self.log.error(e)


### PR DESCRIPTION
On my phone, the SMS database is located at `/data/data/com.android.providers.telephony/databases/mmssms.db` instead of `/data/data/com.google.android.apps.messaging/databases/bugle_db`.

The format of the base itself is also different, so the SQL query had to be adapted :

Original SQL query :
```sql
SELECT 
    ppl.normalized_destination AS number,
    p.timestamp AS timestamp,
CASE WHEN m.sender_id IN 
(SELECT _id FROM participants WHERE contact_id=-1)
THEN 2 ELSE 1 END incoming, p.text AS text 
FROM messages m, conversations c, parts p,
        participants ppl, conversation_participants cp
WHERE (m.conversation_id = c._id)
    AND (m._id = p.message_id)
    AND (cp.conversation_id = c._id)
    AND (cp.participant_id = ppl._id);
```

New SQL query added :
```sql
SELECT 
    address AS number,
    date_sent AS timestamp,
    type as incoming,
    body AS text 
FROM sms;
```

To handle both locations, I added a `_adb_check_file_exists` in `mvt/android/modules/adb/base.py` and the `SMS_DB_TYPE` attribute in class `SMS`