### PR TITLE
Update libimobiledevice docs about backup password reset

### DIFF
--- a/docs/ios/backup/libimobiledevice.md
+++ b/docs/ios/backup/libimobiledevice.md
@@ -3,10 +3,12 @@
 If you have correctly [installed libimobiledevice](../install.md) you can easily generate an iTunes backup using the `idevicebackup2` tool included in the suite. First, you might want to ensure that backup encryption is enabled (**note: encrypted backup contain more data than unencrypted backups**):
 
 ```bash
-idevicebackup2 backup encryption on
+idevicebackup2 -i backup encryption on
 ```
 
-Note that if a backup password was previously set on this device, you might need to use the same or change it. You can try changing password using `idevicebackup2 backup changepw` or resetting the password by resetting only the settings through the iPhone's Settings app.
+Note that if a backup password was previously set on this device, you might need to use the same or change it. You can try changing password using `idevicebackup2 -i backup changepw`, or by turning off encryption (`idevicebackup2 -i backup encryption off`) and turning it back on again.
+
+If that fails, as a last resort you can try resetting the password by [resetting all the settings through the iPhone's Settings app](https://support.apple.com/en-us/HT205220), via `Settings » General » Reset » Reset All Settings`.  Note that resetting the settings through the iPhone's Settings app may wipe some of the files that contain useful forensic traces, so try to reset the device's password using `idevicebackup2` as described above first.
 
 Once ready, you can proceed performing the backup:
 


### PR DESCRIPTION
In this stage, the user is likely to want to run `idevicebackup2` in
interactive mode, so clearly specify the `-i` flag in the right place
(just dropping `-i` at the end of the command does not work as
expected -- i think `idevicebackup2 backup encryption on -i` tries to
set the password to `-i`).

More importantly, note that resetting the password by resetting all
the settings runs a risk of removing some of the forensic information.
Etienne identified a file that he thought was wiped as a result of
this in the call this morning, but I don't remember which file it was.

Maybe `id_status_cache.json` ?  If you have more concrete info, please
add it here too!