### PR TITLE
mvt-ios decrypt-backup: Improve error messages for known cases

### DIFF
--- a/mvt/ios/decrypt.py
+++ b/mvt/ios/decrypt.py
@@ -78,8 +78,13 @@ class DecryptBackup:
                                      cleartextpassword=password,
                                      backuproot=os.path.dirname(self.backup_path))
         except Exception as e:
-            log.exception(e)
-            log.critical("Failed to decrypt backup. Did you provide the correct password?")
+            if isinstance(e, KeyError) and len(e.args) > 0 and e.args[0] == b"KEY":
+                log.critical("Failed to decrypt backup. Password is probably wrong.")
+            elif isinstance(e, FileNotFoundError) and os.path.basename(e.filename) == "Manifest.plist":
+                log.critical(f"Failed to find backup at {self.backup_path}.  Did you need to specify the full path?")
+            else:
+                log.exception(e)
+                log.critical("Failed to decrypt backup. Did you provide the correct password?  Did you point to the right backup path?")
 
     def decrypt_with_key_file(self, key_file):
         """Decrypts an encrypted iOS backup using a key file.


### PR DESCRIPTION
The two most common reasons that `mvt-ios decrypt-backup` can fail are
wrong passwords and not pointing to an actual backup.

We can distinguish these cases based on the kinds of errors thrown
from iOSbackup (at least for the current versions that i'm testing
with).

When we encounter those particular exceptions, just report a simple
summary and don't overwhelm the user with a backtrace.  If we
encounter an unexpected exception, leave the reporting as-is.

Closes: #28, #36