### PR TITLE
mvt-ios sqlite3 db recovery: fix quoting sent to sqlite3 .clone

### DIFF
--- a/mvt/ios/modules/fs/base.py
+++ b/mvt/ios/modules/fs/base.py
@@ -56,7 +56,7 @@ class IOSExtraction(MVTModule):
         bak_path = f"{file_path}.bak"
         shutil.move(file_path, bak_path)
 
-        ret = subprocess.call(["sqlite3", bak_path, f".clone '{file_path}'"],
+        ret = subprocess.call(["sqlite3", bak_path, f".clone \"{file_path}\""],
                               stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         if ret != 0:
             raise DatabaseCorruptedError("Recovery of database failed")


### PR DESCRIPTION
In b2afce5c79b9305028e1ff7bb226a0ef3d9affc5, the db filename is
wrapped in double-quotes when passing it to the sqlite3 tool's
`.clone` helper command.

For parsing safety, we avoid performing this cleanup if the filename
itself has a double-quote character in it.  Otherwise, a malformed
filename could lead to arbitrary injection into the sqlite3 command.

In be2468004613fe3a40dcf6c8acebd8c866d635d3, the sqlite3 wrapping
changes to single-quotes.  Either the safety check should be amended
to block pathnames with single-quotes, or the sqlite3 wrapping should
revert to double-quotes.

I opted for the latter here because i think single-quotes are more
likely than double-quotes to show up in pathnames (e.g. a folder named
"Daniel's files"), but either change would be fine, of course.