### PR TITLE
Log if there was no detection made by the module

### DIFF
--- a/mvt/common/module.py
+++ b/mvt/common/module.py
@@ -167,6 +167,8 @@ def run_module(module):
     else:
         try:
             module.check_indicators()
+            if not module.detected:
+                module.log.info("No detection!")
         except NotImplementedError:
             pass
 


### PR DESCRIPTION
Be more explicit about that nothing was found. Otherwise, users might be wondering if the program has terminated successfully or if something failed.

The last line is new:

```
$ mvt-android check-backup --iocs ~/android-analyse/pegasus.stix2 ~/android-analyse/dominik-android-backup --output ~/android-analyse/dominik-android-backup_out
12:19:15 INFO     [mvt.android.cli] Checking ADB backup located at: /home/dominik/android-analyse/dominik-android-backup     
         INFO     [mvt.android.cli] Loading indicators from provided file at /home/dominik/android-analyse/pegasus.stix2     
         INFO     [mvt.android.modules.backup.sms] Running module SMS...                                                    
         INFO     [mvt.android.modules.backup.sms] Processing SMS backup file at /home/dominik/android-analyse/dominik-android-backup/apps/com.android.providers.telephony/d_f/000001_sms_backup                                       
         INFO     [mvt.android.modules.backup.sms] Extracted a total of 33 SMS messages containing links                    
         INFO     [mvt.android.modules.backup.sms] No detection!
```