### PR TITLE
mvt-ios decrypt-backup: friendlier error handling

### DIFF
--- a/mvt/ios/cli.py
+++ b/mvt/ios/cli.py
@@ -53,7 +53,8 @@ def cli():
               help="File containing raw encryption key to use to decrypt the backup",
               mutually_exclusive=["password"])
 @click.argument("BACKUP_PATH", type=click.Path(exists=True))
-def decrypt_backup(destination, password, key_file, backup_path):
+@click.pass_context
+def decrypt_backup(ctx, destination, password, key_file, backup_path):
     backup = DecryptBackup(backup_path, destination)
 
     if key_file:
@@ -75,6 +76,8 @@ def decrypt_backup(destination, password, key_file, backup_path):
         sekrit = Prompt.ask("Enter backup password", password=True)
         backup.decrypt_with_password(sekrit)
 
+    if not backup.can_process():
+        ctx.exit(1)
     backup.process_backup()
 
 

--- a/mvt/ios/decrypt.py
+++ b/mvt/ios/decrypt.py
@@ -8,6 +8,7 @@ import logging
 import os
 import shutil
 import sqlite3
+import glob
 
 from iOSbackup import iOSbackup
 
@@ -76,6 +77,15 @@ class DecryptBackup:
         """
         log.info("Decrypting iOS backup at path %s with password", self.backup_path)
 
+        if not os.path.exists(os.path.join(self.backup_path, "Manifest.plist")):
+            possible = glob.glob(os.path.join(self.backup_path, "*", "Manifest.plist"))
+            if len(possible) == 1:
+                newpath = os.path.dirname(possible[0])
+                log.warning(f"No Manifest.plist in {self.backup_path}, using {newpath} instead.")
+                self.backup_path = newpath
+            elif len(possible) > 1:
+                log.critical(f"No Manifest.plist in {self.backup_path}, and {len(possible)} Manifest.plist files in subdirs.  Please choose one!")
+                return
         try:
             self._backup = iOSbackup(udid=os.path.basename(self.backup_path),
                                      cleartextpassword=password,

--- a/mvt/ios/decrypt.py
+++ b/mvt/ios/decrypt.py
@@ -28,6 +28,9 @@ class DecryptBackup:
         self._backup = None
         self._decryption_key = None
 
+    def can_process(self) -> bool:
+        return self._backup is not None
+        
     def process_backup(self):
         if not os.path.exists(self.dest_path):
             os.makedirs(self.dest_path)


### PR DESCRIPTION
This series improves on the error handling for `mvt-ios decrypt-backup`, in particular:

- making sure that a failure gets reported as a failure by returning a non-zero
- implementing the friendlier path-finding logic outlined in #147