### PR TITLE
Some esthetic fixes to documentation

### DIFF
--- a/docs/android/backup.md
+++ b/docs/android/backup.md
@@ -44,4 +44,4 @@ $ mvt-android check-backup --output /path/to/results/ /path/to/backup/
                   64 SMS messages containing links
 ```
 
-Through the `--iocs` argument you can specify a [STIX2](https://oasis-open.github.io/cti-documentation/stix/intro) file defining a list of malicious indicators to check against the records extracted from the backup by mvt. Any matches will be highlighted in the terminal output.
+Through the `--iocs` argument you can specify a [STIX2](https://oasis-open.github.io/cti-documentation/stix/intro) file defining a list of malicious indicators to check against the records extracted from the backup by MVT. Any matches will be highlighted in the terminal output.

--- a/docs/android/download_apks.md
+++ b/docs/android/download_apks.md
@@ -20,7 +20,7 @@ mvt-android download-apks --output /path/to/folder --virustotal
 mvt-android download-apks --output /path/to/folder --koodous
 ```
 
-Or, to launch all available lookups::
+Or, to launch all available lookups:
 
 ```bash
 mvt-android download-apks --output /path/to/folder --all-checks

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,6 +1,6 @@
 # Installation
 
-Before proceeding, please note that mvt requires Python 3.6+ to run. While it should be available on most operating systems, please make sure of that before proceeding.
+Before proceeding, please note that MVT requires Python 3.6+ to run. While it should be available on most operating systems, please make sure of that before proceeding.
 
 ## Dependencies on Linux
 
@@ -14,9 +14,9 @@ sudo apt install python3 python3-pip libusb-1.0-0 sqlite3
 
 When working with Android devices you should additionally install [Android SDK Platform Tools](https://developer.android.com/studio/releases/platform-tools). If you prefer to install a package made available by your distribution of choice, please make sure the version is recent to ensure compatibility with modern Android devices.
 
-## Dependencies on Mac
+## Dependencies on macOS
 
-Running MVT on Mac requires Xcode and [homebrew](https://brew.sh) to be installed.
+Running MVT on macOS requires Xcode and [homebrew](https://brew.sh) to be installed.
 
 In order to install dependencies use:
 
@@ -26,7 +26,7 @@ brew install python3 libusb sqlite3
 
 *libusb* is not required if you intend to only use `mvt-ios` and not `mvt-android`.
 
-When working with Android devices you should additionally install Android SDK Platform Tools:
+When working with Android devices you should additionally install [Android SDK Platform Tools](https://developer.android.com/studio/releases/platform-tools):
 
 ```bash
 brew install --cask android-platform-tools

--- a/docs/ios/backup/itunes.md
+++ b/docs/ios/backup/itunes.md
@@ -1,16 +1,16 @@
 # Backup with iTunes app
 
-It is possible to do an iPhone backup by using iTunes on Windows or Mac computers (in most recent versions of Mac OS, this feature is included in Finder).
+It is possible to do an iPhone backup by using iTunes on Windows or macOS computers (in most recent versions of macOS, this feature is included in Finder).
 
 To do that:
 
 * Make sure iTunes is installed.
 * Connect your iPhone to your computer using a Lightning/USB cable.
-* Open the device in iTunes (or Finder on Mac OS).
+* Open the device in iTunes (or Finder on macOS).
 * If you want to have a more accurate detection, ensure that the encrypted backup option is activated and choose a secure password for the backup.
 * Start the backup and wait for it to finish (this may take up to 30 minutes).
 
 ![](../../../img/macos-backup.jpg)
 _Source: [Apple Support](https://support.apple.com/en-us/HT211229)_
 
-* Once the backup is done, find its location and copy it to a place where it can be analyzed by `mvt`. On Windows, the backup can be stored either in `%USERPROFILE%\Apple\MobileSync\` or `%USERPROFILE%\AppData\Roaming\Apple Computer\MobileSync\`. On Mac OS, the backup is stored in `~/Library/Application Support/MobileSync/`.
+* Once the backup is done, find its location and copy it to a place where it can be analyzed by MVT. On Windows, the backup can be stored either in `%USERPROFILE%\Apple\MobileSync\` or `%USERPROFILE%\AppData\Roaming\Apple Computer\MobileSync\`. On macOS, the backup is stored in `~/Library/Application Support/MobileSync/`.

--- a/docs/ios/methodology.md
+++ b/docs/ios/methodology.md
@@ -12,4 +12,4 @@ If you are not expected to return the phone, you might want to consider to attem
 
 #### iTunes Backup
 
-An alternative option is to generate an iTunes backup (in most recent version of mac OS, they are no longer launched from iTunes, but directly from Finder). While backups only provide a subset of the files stored on the device, in many cases it might be sufficient to at least detect some suspicious artifacts. Backups encrypted with a password will have some additional interesting records not available in unencrypted ones, such as Safari history, Safari state, etc.
+An alternative option is to generate an iTunes backup (in most recent version of macOS, they are no longer launched from iTunes, but directly from Finder). While backups only provide a subset of the files stored on the device, in many cases it might be sufficient to at least detect some suspicious artifacts. Backups encrypted with a password will have some additional interesting records not available in unencrypted ones, such as Safari history, Safari state, etc.


### PR DESCRIPTION
Just some esthetic fixes to uniform documentation (i.e. MVT is always capitalized)