### PR TITLE
Create adb keys (Fixes #165)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -73,6 +73,10 @@ RUN mkdir /opt/android \
 # Create alias for adb 
   && echo 'alias adb="/opt/android/platform-tools/adb"' >> ~/.bashrc 
 
+# Generate adb key folder 
+# ------------------------------ 
+RUN mkdir /root/.android && /opt/android/platform-tools/adb keygen /root/.android/adbkey
+
 # Setup investigations environment
 # --------------------------------
 RUN mkdir /home/cases


### PR DESCRIPTION
This minor patch creates a .android directory and generates security keys. 

This patch fixes the following error: 

```

Traceback (most recent call last):
  File "/usr/local/bin/mvt-android", line 8, in <module>
    sys.exit(cli())
  File "/usr/local/lib/python3.8/dist-packages/click/core.py", line 1137, in __call__
    return self.main(*args, **kwargs)
  File "/usr/local/lib/python3.8/dist-packages/click/core.py", line 1062, in main
    rv = self.invoke(ctx)
  File "/usr/local/lib/python3.8/dist-packages/click/core.py", line 1668, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/usr/local/lib/python3.8/dist-packages/click/core.py", line 1404, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/usr/local/lib/python3.8/dist-packages/click/core.py", line 763, in invoke
    return __callback(*args, **kwargs)
  File "/usr/local/lib/python3.8/dist-packages/mvt/android/cli.py", line 70, in download_apks
    download.run()
  File "/usr/local/lib/python3.8/dist-packages/mvt/android/download_apks.py", line 210, in run
    self._adb_connect()
  File "/usr/local/lib/python3.8/dist-packages/mvt/android/modules/adb/base.py", line 51, in _adb_connect
    self._adb_check_keys()
  File "/usr/local/lib/python3.8/dist-packages/mvt/android/modules/adb/base.py", line 43, in _adb_check_keys
    keygen(ADB_KEY_PATH)
  File "/usr/local/lib/python3.8/dist-packages/adb_shell/auth/keygen.py", line 248, in keygen
    with open(filepath, 'wb') as private_key_file:
FileNotFoundError: [Errno 2] No such file or directory: '/root/.android/adbkey'

```