### PR TITLE
Fixes a bug in retrieving the backup file path in webkit session resource log

### DIFF
--- a/mvt/ios/modules/mixed/webkit_session_resource_log.py
+++ b/mvt/ios/modules/mixed/webkit_session_resource_log.py
@@ -113,7 +113,10 @@ class WebkitSessionResourceLog(IOSExtraction):
 
     def run(self):
         if self.is_backup:
-            for log_path in self._get_backup_files_from_manifest(relative_path=WEBKIT_SESSION_RESOURCE_LOG_BACKUP_RELPATH):
+            for log_file in self._get_backup_files_from_manifest(relative_path=WEBKIT_SESSION_RESOURCE_LOG_BACKUP_RELPATH):
+                log_path = self._get_backup_file_from_id(log_file["file_id"])
+                if not log_path:
+                    continue
                 self.log.info("Found Safari browsing session resource log at path: %s", log_path)
                 self.results[log_path] = self._extract_browsing_stats(log_path)
         elif self.is_fs_dump:


### PR DESCRIPTION
This PR is fixing a bug in `webkit_session_resource_log.py`:

```
ERROR    [mvt.ios.modules.mixed.webkit_session_resource_log]
                  Error in running extraction from module WebkitSessionResourceLog: expected str, bytes or os.PathLike object, not dict
                  Traceback (most recent call last):
                    File "mvt/mvt/common/module.py", line 144, in run_module
                      module.run()
                    File "mvt/mvt/ios/modules/mixed/webkit_session_resource_log.py", line 118, in run
                      self.results[log_path] =self._extract_browsing_stats(log_path)
                    File "mvt/mvt/ios/modules/mixed/webkit_session_resource_log.py", line 92,
                  in _extract_browsing_stats
                      with open(log_path, "rb") as handle:
                  TypeError: expected str, bytes or os.PathLike object, not dict
```

The error came from mishandling the returned value of `_get_backup_files_from_manifest`