### PR TITLE
New artefact, com.apple.osanalytics.addaily.plist

### DIFF
--- a/docs/ios/records.md
+++ b/docs/ios/records.md
@@ -148,6 +148,18 @@ If indicators are provided through the command-line, they are checked against th
 
 ---
 
+### `osanalyticsdaily.json`
+
+!!! info "Availability"
+    Backup: :material-check:  
+    Full filesystem dump: :material-check:
+
+This JSON file is created by mvt-ios' `OSAnalyticsADDAILY` module. The module extracts records from a plist located *private/var/mobile/Library/Preferences/com.apple.osanalytics.addaily.plist*, which contains a history of data usage by processes running on the system. Besides the network statistics, these records are particularly important because they might show traces of malicious process executions and the relevant timeframe.
+
+If indicators are provided through the command-line, they are checked against the process names. Any matches are stored in *osanalyticsdaily_detected.json*.
+
+---
+
 ### `datausage.json`
 
 !!! info "Availability"

--- a/mvt/ios/modules/mixed/__init__.py
+++ b/mvt/ios/modules/mixed/__init__.py
@@ -13,6 +13,7 @@ from .idstatuscache import IDStatusCache
 from .interactionc import InteractionC
 from .locationd import LocationdClients
 from .net_datausage import Datausage
+from .osanalytics_addaily import OSAnalyticsADDAILY
 from .safari_browserstate import SafariBrowserState
 from .safari_history import SafariHistory
 from .sms import SMS
@@ -22,6 +23,6 @@ from .webkit_session_resource_log import WebkitSessionResourceLog
 from .whatsapp import Whatsapp
 
 MIXED_MODULES = [Calls, ChromeFavicon, ChromeHistory, Contacts, FirefoxFavicon,
-                 FirefoxHistory, IDStatusCache, InteractionC, LocationdClients,
+                 FirefoxHistory, IDStatusCache, InteractionC, LocationdClients, OSAnalyticsADDAILY,
                  Datausage, SafariBrowserState, SafariHistory, SMS, SMSAttachments,
                  WebkitResourceLoadStatistics, WebkitSessionResourceLog, Whatsapp,]

--- a/mvt/ios/modules/mixed/osanalytics_addaily.py
+++ b/mvt/ios/modules/mixed/osanalytics_addaily.py
@@ -1,0 +1,72 @@
+# Mobile Verification Toolkit (MVT)
+# Copyright (c) 2021 The MVT Project Authors.
+# Use of this software is governed by the MVT License 1.1 that can be found at
+#   https://license.mvt.re/1.1/
+
+import plistlib
+
+from mvt.common.utils import convert_timestamp_to_iso
+
+from ..base import IOSExtraction
+
+OSANALYTICS_ADDAILY_BACKUP_IDS = [
+    "f65b5fafc69bbd3c60be019c6e938e146825fa83",
+]
+OSANALYTICS_ADDAILY_ROOT_PATHS = [
+    "private/var/mobile/Library/Preferences/com.apple.osanalytics.addaily.plist",
+]
+
+class OSAnalyticsADDAILY(IOSExtraction):
+    """Extract network usage information by process, from com.apple.osanalytics.addaily.plist"""
+
+    def __init__(self, file_path=None, base_folder=None, output_folder=None,
+                 fast_mode=False, log=None, results=[]):
+        super().__init__(file_path=file_path, base_folder=base_folder,
+                         output_folder=output_folder, fast_mode=fast_mode,
+                         log=log, results=results)
+
+    def serialize(self, record):
+        record_data = f"{record['package']}"
+        record_data_usage = record_data + f" WIFI IN: {record['wifi_in']}, WIFI OUT: {record['wifi_out']} - "  \
+                            f"WWAN IN: {record['wwan_in']}, WWAN OUT: {record['wwan_out']}"
+
+        records = [{
+            "timestamp": record["ts"],
+            "module": self.__class__.__name__,
+            "event": "date",
+            "data": record_data_usage,
+        }]
+
+        return records
+    
+    def check_indicators(self):
+        if not self.indicators:
+            return
+
+        for result in self.results:
+            if self.indicators.check_process(result["package"]):
+                    self.detected.append(result)
+
+    def run(self):
+        self._find_ios_database(backup_ids=OSANALYTICS_ADDAILY_BACKUP_IDS,
+                                root_paths=OSANALYTICS_ADDAILY_ROOT_PATHS)
+        self.log.info("Found com.apple.osanalytics.addaily plist at path: %s", self.file_path)
+
+        with open(self.file_path, "rb") as handle:
+            file_plist = plistlib.load(handle)
+
+        for app in file_plist.get("netUsageBaseline"):
+            result = {}
+            result_list = file_plist.get("netUsageBaseline").get(app)
+            
+            if type(result_list) is list:
+                result["package"] = app
+                result["ts"] = convert_timestamp_to_iso(result_list[0])
+                result["wifi_in"] = result_list[1]
+                result["wifi_out"] = result_list[2]
+                result["wwan_in"] = result_list[3]
+                result["wwan_out"] = result_list[4]
+
+                self.results.append(result)
+
+        self.log.info("Extracted a total of %d com.apple.osanalytics.addaily entries", len(self.results))


### PR DESCRIPTION
This PR adds a new module, `OSAnalyticsADDAILY`, which will collect and parse the file `com.apple.osanalytics.addaily.plist`.

This file is a plist which contains records similar to this :

```
...
<key>coreduetd</key>
<array>
    <date>2020-10-27T13:56:40Z</date>
    <real>3232269</real>
    <real>6847771</real>
    <real>82337</real>
    <real>43704</real>
</array>
...
```

I could not find documentation for this file online, but comparing it with NetUsage.sqlite and DataUsage.sqlite allowed me to confirm that the `real` attributes were for `wifi_in`, `wifi_out`, `wwan_in` and `wwan_out`.


Adding this module will :
- look for malicious processes in a new file (sometimes processes are only seen in this file and not in DataUsage.sqlite or NetUsage.sqlite)
- add a new information source for network usage, which will log data usage for wifi and wwan (contrary to DataUsage, which will only record wwan)