### PR TITLE
fix multi path/file issue

### DIFF
--- a/mvt/ios/modules/mixed/idstatuscache.py
+++ b/mvt/ios/modules/mixed/idstatuscache.py
@@ -51,11 +51,7 @@ class IDStatusCache(IOSExtraction):
                                  result.get("user"))
                 self.detected.append(result)
 
-    def run(self):
-        self._find_ios_database(backup_ids=IDSTATUSCACHE_BACKUP_IDS,
-                                root_paths=IDSTATUSCACHE_ROOT_PATHS)
-        self.log.info("Found IDStatusCache plist at path: %s", self.file_path)
-
+    def extract_idstatuscache_entries(self):
         with open(self.file_path, "rb") as handle:
             file_plist = plistlib.load(handle)
 
@@ -84,4 +80,16 @@ class IDStatusCache(IOSExtraction):
             entry["occurrences"] = entry_counter[entry["user"]]
             self.results.append(entry)
 
+    def run(self):
+
+        if self.is_backup:
+            self._find_ios_database(backup_ids=IDSTATUSCACHE_BACKUP_IDS)
+            self.log.info("Found IDStatusCache plist at path: %s", self.file_path)
+            self.extract_idstatuscache_entries()
+        elif self.is_fs_dump:
+            for idstatuscache_path in self._get_fs_files_from_patterns(IDSTATUSCACHE_ROOT_PATHS):
+                self.file_path = idstatuscache_path
+                self.log.info("Found IDStatusCache plist at path: %s", self.file_path)
+                self.extract_idstatuscache_entries()
+            
         self.log.info("Extracted a total of %d ID Status Cache entries", len(self.results))


### PR DESCRIPTION
For IDStatusCache, LocationdClients and SafariBrowserState modules running on a filesystem, when multiple *_ROOT_PATHS are valid, using `_find_ios_database` will only set as `self.file_path` (and therefore process) the first valid path found.

However, those files can exist at multiple locations, and they should all be parsed.

This can miss IDStatusCache, LocationdClients and SafariBrowserState entries if an empty or incorrect file is at the first indicated path, and valid and additional entries are located at the other paths.

For SafariBrowserState, the `SAFARI_BROWSER_STATE_BACKUP_IDS` was removed as the patch uses `_get_backup_files_from_manifest` instead.

(this fix is similar to what is done for Netusage, SafariFavicon, SafariHistory etc. ; all modules that use `_get_fs_files_from_patterns`)

PS : sorry for the duplicate, messed up