### PR TITLE
fix error for manipulated entries in DataUsage/NetUsage

### DIFF
--- a/mvt/ios/modules/net_base.py
+++ b/mvt/ios/modules/net_base.py
@@ -145,7 +145,9 @@ class NetBase(IOSExtraction):
                     self.log.debug("Located at %s", binary_path)
                 else:
                     msg = f"Could not find the binary associated with the process with name {proc['proc_name']}"
-                    if len(proc["proc_name"]) == 16:
+                    if (proc["proc_name"] is None):
+                        msg = f"Found process entry with empty 'proc_name' : {proc['live_proc_id']} at {proc['live_isodate']}"
+                    elif len(proc["proc_name"]) == 16:
                         msg = msg + " (However, the process name might have been truncated in the database)"
 
                     self.log.warning(msg)


### PR DESCRIPTION
`check_manipulated` will check for missing or manipulated DB entries.

However, if `proc["proc_name"]` is not defined, `len(proc["proc_name"])` in `_find_suspicious_processes` ([here](https://github.com/mvt-project/mvt/blob/e5f2aa3c3d651b1fe8a0401cce82d3eeb6d7e178/mvt/ios/modules/net_base.py#L148)) will throw out an error (as `proc["proc_name"] is None`)

This error will interrupt the whole module, stopping the parsing of the file and not launching `check_manipulated()` or `find_deleted()`.

This patch makes sure this does not happen by checking that `proc["proc_name"]` is not `None`