### PR TITLE
New artefact, shutdown.log

### DIFF
--- a/docs/ios/records.md
+++ b/docs/ios/records.md
@@ -230,6 +230,18 @@ If indicators are provided through the command-line, they are checked against th
 
 ---
 
+### `shutdown_log.json`
+
+!!! info "Availability"
+    Backup (if encrypted): :material-close:  
+    Full filesystem dump: :material-check:
+
+This JSON file is created by mvt-ios' `ShutdownLog` module. The module extracts records from the shutdown log located at *private/var/db/diagnostics/shutdown.log*. When shutting down an iPhone, a SIGTERM will be sent to all processes runnning. The `shutdown.log` file will log any process (with its pid and path) that did not shut down after the SIGTERM was sent. 
+
+If indicators are provided through the command-line, they are checked against the paths. Any matches are stored in *shutdown_log_detected.json*.
+
+---
+
 ### `sms.json`
 
 !!! info "Availability"

--- a/mvt/common/indicators.py
+++ b/mvt/common/indicators.py
@@ -163,10 +163,12 @@ class Indicators:
 
         return False
 
-    def check_process(self, process) -> bool:
+    def check_process(self, process, contains = False) -> bool:
         """Check the provided process name against the list of process
         indicators.
 
+        :param contains: Check if the process is contained inside the string.
+        :type process: bool
         :param process: Process name to check against process indicators
         :type process: str
         :returns: True if process matched an indicator, otherwise False
@@ -174,6 +176,12 @@ class Indicators:
         """
         if not process:
             return False
+
+        if (contains):
+            for malicious_process in self.ioc_processes:
+                if malicious_process in process:
+                    self.log.warning("Found a known suspicious process name (\"%s\") in \"%s\"", malicious_process, process)
+                    return True
 
         proc_name = os.path.basename(process)
         if proc_name in self.ioc_processes:

--- a/mvt/ios/modules/fs/__init__.py
+++ b/mvt/ios/modules/fs/__init__.py
@@ -7,10 +7,11 @@ from .cache_files import CacheFiles
 from .filesystem import Filesystem
 from .net_netusage import Netusage
 from .safari_favicon import SafariFavicon
+from .shutdown import ShutdownLog
 from .version_history import IOSVersionHistory
 from .webkit_indexeddb import WebkitIndexedDB
 from .webkit_localstorage import WebkitLocalStorage
 from .webkit_safariviewservice import WebkitSafariViewService
 
-FS_MODULES = [CacheFiles, Filesystem, Netusage, SafariFavicon, IOSVersionHistory,
+FS_MODULES = [CacheFiles, Filesystem, Netusage, SafariFavicon, ShutdownLog, IOSVersionHistory,
               WebkitIndexedDB, WebkitLocalStorage, WebkitSafariViewService,]

--- a/mvt/ios/modules/fs/shutdown.py
+++ b/mvt/ios/modules/fs/shutdown.py
@@ -1,0 +1,67 @@
+# Mobile Verification Toolkit (MVT)
+# Copyright (c) 2021 The MVT Project Authors.
+# Use of this software is governed by the MVT License 1.1 that can be found at
+#   https://license.mvt.re/1.1/
+
+from mvt.common.utils import convert_mactime_to_unix, convert_timestamp_to_iso
+
+from ..base import IOSExtraction
+
+SHUTDOWN_LOG_PATH = [
+    "private/var/db/diagnostics/shutdown.log",
+]
+
+class ShutdownLog(IOSExtraction):
+    """This module extracts processes information from the shutdown log file."""
+
+    def __init__(self, file_path=None, base_folder=None, output_folder=None,
+                 fast_mode=False, log=None, results=[]):
+        super().__init__(file_path=file_path, base_folder=base_folder,
+                         output_folder=output_folder, fast_mode=fast_mode,
+                         log=log, results=results)
+
+    def serialize(self, record):
+        return {
+            "timestamp": record["isodate"],
+            "module": self.__class__.__name__,
+            "event": "shutdown",
+            "data": f"Client {record['client']} with PID {record['pid']} was running when the device was shut down",
+        }
+    
+
+    def check_indicators(self):
+        if not self.indicators:
+            return
+
+        for result in self.results:
+            if self.indicators.check_process(result["client"], True):
+                self.detected.append(result)
+
+    def run(self):
+        self._find_ios_database(root_paths=SHUTDOWN_LOG_PATH)
+        self.log.info("Found shutdown log at path: %s", self.file_path)
+        
+        with open(self.file_path, "r") as shutdown_log:
+            shutdown_log_lines = shutdown_log.readlines()
+            date = "0000-00-00 00:00:00.000000 (unknown)"
+
+            for line in shutdown_log_lines:
+                if line.startswith("After "):
+                    continue
+
+                elif line.startswith("\t\tremaining client pid: "):
+                    pid = int(line.split("\t\tremaining client pid: ")[1].split(" ")[0])
+                    client = line.split("(")[1].split(")")[0]
+                    entry = {
+                        "isodate": date,
+                        "pid": pid,
+                        "client": client
+                    }
+                    if entry not in self.results:
+                        self.results.append(entry)
+
+                elif line.startswith("SIGTERM: ["):
+                    isodate = int(line.split("[")[1].split("]")[0])
+                    date = convert_timestamp_to_iso(convert_mactime_to_unix(isodate, False))
+
+        self.results = sorted(self.results, key=lambda entry: entry["isodate"])


### PR DESCRIPTION
This PR adds a new module, `ShutdownLog`, which will collect and parse the shutdown.log file, located at `private/var/db/diagnostics/shutdown.log`

When shutting down an iPhone, a SIGTERM will be sent to all processes running. The `shutdown.log` file will log any process (with its pid and path) that did not shut down after the SIGTERM was sent, with the timestamp at which the SIGTERM was sent.

`shutdown.log` is a multiline log file which contains records similar to this :

```
SIGTERM: [<TIMESTAMP>] All buffers flushed
After X.XXs, these clients are still here:
		remaining client pid: 1 (<path1>)
		remaining client pid: 2 (<path2>)
		remaining client pid: 3 (<path3>)
		remaining client pid: 4 (<path4>)
After X.XXs, these clients are still here:
		remaining client pid: 1 (<path1>)
		remaining client pid: 2 (<path2>)
		remaining client pid: 4 (<path4>)
[...]
SIGTERM: [<TIMESTAMP>] All buffers flushed
```

The path contains the process name, and therefore malicious processes can be looked in this file.

I could not find any documentation or tool to parse it, so the code is quite sketchy but functional. The first date can be unknown, because the first timestamp can be missing.

I had to modify the `check_process` function to add a boolean which will allow searching for suspicious process names inside of the path.

The malicious process `bh` can probably raise some false positives.