### PR TITLE
Specify public key for PythonRSASigner

### DIFF
--- a/mvt/android/modules/adb/base.py
+++ b/mvt/android/modules/adb/base.py
@@ -56,7 +56,10 @@ class AndroidExtraction(MVTModule):
         with open(ADB_KEY_PATH, "rb") as handle:
             priv_key = handle.read()
 
-        signer = PythonRSASigner("", priv_key)
+        with open(ADB_PUB_KEY_PATH, "rb") as handle:
+            pub_key = handle.read()
+
+        signer = PythonRSASigner(pub_key, priv_key)
 
         # If no serial was specified or if the serial does not seem to be
         # a HOST:PORT definition, we use the USB transport.


### PR DESCRIPTION
On android 11 at least, the authentication does not work currently unless public key is also specified. It fails with `LIBUSB_ERROR_TIMEOUT`

It has also been updated in adb_shell (https://github.com/JeffLIrion/adb_shell/pull/119/commits/e2106e3dd3f6d5685eb9cdb4b6c8981c512cc962) 

Might fix: https://github.com/mvt-project/mvt/issues/53, https://github.com/mvt-project/mvt/issues/113