### PR TITLE
Fix ConfigurationProfiles

### DIFF
--- a/mvt/ios/modules/backup/configuration_profiles.py
+++ b/mvt/ios/modules/backup/configuration_profiles.py
@@ -41,7 +41,7 @@ class ConfigurationProfiles(IOSExtraction):
                conf_plist["LastPushTokenHash"] = b64encode(conf_plist["LastPushTokenHash"])
             if "PayloadContent" in conf_plist:
                for x in range(len(conf_plist["PayloadContent"])):
-                   if "PERSISTENT_REF" in conf_plist["PayloadContent"]:
+                   if "PERSISTENT_REF" in conf_plist["PayloadContent"][x]:
                        conf_plist["PayloadContent"][x]["PERSISTENT_REF"] = b64encode(conf_plist["PayloadContent"][x]["PERSISTENT_REF"])
 
             self.results.append({

--- a/mvt/ios/modules/backup/configuration_profiles.py
+++ b/mvt/ios/modules/backup/configuration_profiles.py
@@ -1,3 +1,4 @@
+
 # Mobile Verification Toolkit (MVT)
 # Copyright (c) 2021 The MVT Project Authors.
 # Use of this software is governed by the MVT License 1.1 that can be found at
@@ -27,10 +28,21 @@ class ConfigurationProfiles(IOSExtraction):
                 continue
 
             with open(conf_file_path, "rb") as handle:
-                conf_plist = plistlib.load(handle)
+                try:
+                    conf_plist = plistlib.load(handle)
+                except:
+                    conf_plist = {}
 
             if "SignerCerts" in conf_plist:
                 conf_plist["SignerCerts"] = [b64encode(x) for x in conf_plist["SignerCerts"]]
+            if "PushTokenDataSentToServerKey" in conf_plist:
+               conf_plist["PushTokenDataSentToServerKey"] = b64encode(conf_plist["PushTokenDataSentToServerKey"])
+            if "LastPushTokenHash" in conf_plist:
+               conf_plist["LastPushTokenHash"] = b64encode(conf_plist["LastPushTokenHash"])
+            if "PayloadContent" in conf_plist:
+               for x in range(len(conf_plist["PayloadContent"])):
+                   if "PERSISTENT_REF" in conf_plist["PayloadContent"]:
+                       conf_plist["PayloadContent"][x]["PERSISTENT_REF"] = b64encode(conf_plist["PayloadContent"][x]["PERSISTENT_REF"])
 
             self.results.append({
                 "file_id": conf_file["file_id"],


### PR DESCRIPTION
This PR will fix some errors that would occur when parsing `configurationprofiles` files.

This will fix two bugs :

- If the plist file is empty, `plist.load` ([here](https://github.com/mvt-project/mvt/blob/356bddc3af79677792f1d7554e4f9f09e1948adf/mvt/ios/modules/backup/configuration_profiles.py#L30)) would fail, which will make the entire module fail
- If the plist contains bytes, they need to be b64 encoded. This was done for `SignerCerts`, but also had to be done for some other fields.