### PR TITLE
Make utf-8 as a default for open()

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -131,3 +131,6 @@ dmypy.json
 
 # Temporal files
 *~
+
+# IDEA Dev Environment
+.idea

--- a/dev/mvt-android
+++ b/dev/mvt-android
@@ -6,10 +6,6 @@
 
 import os
 import sys
-import importlib
-
-importlib.reload(sys)
-print(sys.getdefaultencoding())
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 

--- a/dev/mvt-android
+++ b/dev/mvt-android
@@ -6,6 +6,10 @@
 
 import os
 import sys
+import importlib
+
+importlib.reload(sys)
+print(sys.getdefaultencoding())
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 

--- a/mvt/android/download_apks.py
+++ b/mvt/android/download_apks.py
@@ -57,7 +57,7 @@ class DownloadAPKs(AndroidExtraction):
         :param json_path: Path to the apks.json file to parse.
 
         """
-        with open(json_path, "r") as handle:
+        with open(json_path, "r", encoding="utf-8") as handle:
             packages = json.load(handle)
             return cls(packages=packages)
 
@@ -173,7 +173,7 @@ class DownloadAPKs(AndroidExtraction):
     def save_json(self):
         """Save the results to the package.json file."""
         json_path = os.path.join(self.output_folder, "apks.json")
-        with open(json_path, "w") as handle:
+        with open(json_path, "w", encoding="utf-8") as handle:
             json.dump(self.packages, handle, indent=4)
 
     def run(self):

--- a/mvt/android/modules/adb/dumpsys_batterystats.py
+++ b/mvt/android/modules/adb/dumpsys_batterystats.py
@@ -27,7 +27,7 @@ class DumpsysBatterystats(AndroidExtraction):
         if self.output_folder:
             stats_path = os.path.join(self.output_folder,
                                       "dumpsys_batterystats.txt")
-            with open(stats_path, "w") as handle:
+            with open(stats_path, "w", encoding="utf-8") as handle:
                 handle.write(stats)
 
             log.info("Records from dumpsys batterystats stored at %s",
@@ -37,7 +37,7 @@ class DumpsysBatterystats(AndroidExtraction):
         if self.output_folder:
             history_path = os.path.join(self.output_folder,
                                         "dumpsys_batterystats_history.txt")
-            with open(history_path, "w") as handle:
+            with open(history_path, "w", encoding="utf-8") as handle:
                 handle.write(history)
 
             log.info("History records from dumpsys batterystats stored at %s",

--- a/mvt/android/modules/adb/dumpsys_full.py
+++ b/mvt/android/modules/adb/dumpsys_full.py
@@ -27,7 +27,7 @@ class DumpsysFull(AndroidExtraction):
         if self.output_folder:
             stats_path = os.path.join(self.output_folder,
                                       "dumpsys.txt")
-            with open(stats_path, "w") as handle:
+            with open(stats_path, "w", encoding="utf-8") as handle:
                 handle.write(stats)
 
             log.info("Full dumpsys output stored at %s",

--- a/mvt/android/modules/adb/dumpsys_packages.py
+++ b/mvt/android/modules/adb/dumpsys_packages.py
@@ -28,7 +28,7 @@ class DumpsysPackages(AndroidExtraction):
         if self.output_folder:
             packages_path = os.path.join(self.output_folder,
                                          "dumpsys_packages.txt")
-            with open(packages_path, "w") as handle:
+            with open(packages_path, "w", encoding="utf-8") as handle:
                 handle.write(output)
 
             log.info("Records from dumpsys package stored at %s",

--- a/mvt/android/modules/adb/dumpsys_procstats.py
+++ b/mvt/android/modules/adb/dumpsys_procstats.py
@@ -27,7 +27,7 @@ class DumpsysProcstats(AndroidExtraction):
         if self.output_folder:
             procstats_path = os.path.join(self.output_folder,
                                           "dumpsys_procstats.txt")
-            with open(procstats_path, "w") as handle:
+            with open(procstats_path, "w", encoding="utf-8") as handle:
                 handle.write(output)
 
             log.info("Records from dumpsys procstats stored at %s",

--- a/mvt/android/modules/adb/logcat.py
+++ b/mvt/android/modules/adb/logcat.py
@@ -31,7 +31,7 @@ class Logcat(AndroidExtraction):
         if self.output_folder:
             logcat_path = os.path.join(self.output_folder,
                                        "logcat.txt")
-            with open(logcat_path, "w") as handle:
+            with open(logcat_path, "w", encoding="utf-8") as handle:
                 handle.write(output)
 
             log.info("Current logcat logs stored at %s",
@@ -39,7 +39,7 @@ class Logcat(AndroidExtraction):
 
             logcat_last_path = os.path.join(self.output_folder,
                                             "logcat_last.txt")
-            with open(logcat_last_path, "w") as handle:
+            with open(logcat_last_path, "w", encoding="utf-8") as handle:
                 handle.write(last_output)
 
             log.info("Logcat logs prior to last reboot stored at %s",

--- a/mvt/common/indicators.py
+++ b/mvt/common/indicators.py
@@ -82,7 +82,7 @@ class Indicators:
         ioc_file["file_path"] = file_path
         ioc_file["file_name"] = os.path.basename(file_path)
 
-        with open(file_path, "r") as handle:
+        with open(file_path, "r", encoding="utf-8") as handle:
             try:
                 data = json.load(handle)
             except json.decoder.JSONDecodeError:

--- a/mvt/common/module.py
+++ b/mvt/common/module.py
@@ -58,7 +58,7 @@ class MVTModule(object):
 
     @classmethod
     def from_json(cls, json_path, log=None):
-        with open(json_path, "r") as handle:
+        with open(json_path, "r", encoding="utf-8") as handle:
             results = json.load(handle)
             if log:
                 log.info("Loaded %d results from \"%s\"",

--- a/mvt/ios/decrypt.py
+++ b/mvt/ios/decrypt.py
@@ -185,7 +185,7 @@ class DecryptBackup:
             return
 
         try:
-            with open(key_path, 'w') as handle:
+            with open(key_path, 'w', encoding="utf-8") as handle:
                 handle.write(self._decryption_key)
         except Exception as e:
             log.exception(e)

--- a/mvt/ios/modules/fs/shutdownlog.py
+++ b/mvt/ios/modules/fs/shutdownlog.py
@@ -86,5 +86,5 @@ class ShutdownLog(IOSExtraction):
     def run(self):
         self._find_ios_database(root_paths=SHUTDOWN_LOG_PATH)
         self.log.info("Found shutdown log at path: %s", self.file_path)
-        with open(self.file_path, "r") as handle:
+        with open(self.file_path, "r", encoding="utf-8") as handle:
             self.process_shutdownlog(handle.read())

--- a/mvt/ios/modules/fs/version_history.py
+++ b/mvt/ios/modules/fs/version_history.py
@@ -34,7 +34,7 @@ class IOSVersionHistory(IOSExtraction):
 
     def run(self):
         for found_path in self._get_fs_files_from_patterns(IOS_ANALYTICS_JOURNAL_PATHS):
-            with open(found_path, "r") as analytics_log:
+            with open(found_path, "r", encoding="utf-8") as analytics_log:
                 log_line = json.loads(analytics_log.readline().strip())
 
                 timestamp = datetime.datetime.strptime(log_line["timestamp"],

--- a/tests/artifacts/generate_stix.py
+++ b/tests/artifacts/generate_stix.py
@@ -41,7 +41,7 @@ def generate_test_stix_file(file_path):
         res.append(Relationship(i, "indicates", malware))
 
     bundle = Bundle(objects=res)
-    with open(file_path, "w+") as f:
+    with open(file_path, "w+", encoding="utf-8") as f:
         f.write(bundle.serialize(pretty=True))
 
 


### PR DESCRIPTION
Not every system uses utf-8 as a default encoding for `open()`, so it is better to write argument `encoding="utf-8"` when using `open()` function in Python. I've tried to find a way to set utf-8 as a default encoding for opening files, but, there is no possibility to do this.

Also, this should fix this errors like this one:
![Image](https://user-images.githubusercontent.com/82591945/151659273-478c0681-286e-4f7f-85a5-6a4c8bad47b4.png)
