### PR TITLE
Adds logging of execution timeline in log file and optional hashing of input files

### DIFF
--- a/mvt/android/cli.py
+++ b/mvt/android/cli.py
@@ -22,7 +22,7 @@ from mvt.common.help import (HELP_MSG_FAST, HELP_MSG_IOC,
                              HELP_MSG_OUTPUT, HELP_MSG_SERIAL)
 from mvt.common.indicators import Indicators, download_indicators_files
 from mvt.common.logo import logo
-from mvt.common.module import run_module, save_timeline
+from mvt.common.module import run_module, save_timeline, save_logs
 
 from .download_apks import DownloadAPKs
 from .lookups.koodous import koodous_lookup
@@ -128,14 +128,17 @@ def check_adb(ctx, iocs, output, fast, list_modules, module, serial):
 
         return
 
-    log.info("Checking Android through adb bridge")
-
     if output and not os.path.exists(output):
         try:
             os.makedirs(output)
         except Exception as e:
             log.critical("Unable to create output folder %s: %s", output, e)
             ctx.exit(1)
+
+    if output:
+        save_logs(log, os.path.join(output, "logs.txt"))
+
+    log.info("Checking Android through adb bridge")
 
     indicators = Indicators(log=log)
     indicators.load_indicators_files(iocs)
@@ -184,14 +187,17 @@ def check_bugreport(ctx, iocs, output, list_modules, module, bugreport_path):
 
         return
 
-    log.info("Checking an Android Bug Report located at: %s", bugreport_path)
-
     if output and not os.path.exists(output):
         try:
             os.makedirs(output)
         except Exception as e:
             log.critical("Unable to create output folder %s: %s", output, e)
             ctx.exit(1)
+
+    if output:
+        save_logs(log, os.path.join(output, "logs.txt"))
+
+    log.info("Checking an Android Bug Report located at: %s", bugreport_path)
 
     indicators = Indicators(log=log)
     indicators.load_indicators_files(iocs)

--- a/mvt/android/cli.py
+++ b/mvt/android/cli.py
@@ -22,7 +22,7 @@ from mvt.common.help import (HELP_MSG_FAST, HELP_MSG_IOC,
                              HELP_MSG_OUTPUT, HELP_MSG_SERIAL)
 from mvt.common.indicators import Indicators, download_indicators_files
 from mvt.common.logo import logo
-from mvt.common.module import run_module, save_timeline, save_logs, save_hashes
+from mvt.common.module import run_module, save_timeline, save_logs, save_info
 
 from .download_apks import DownloadAPKs
 from .lookups.koodous import koodous_lookup
@@ -196,12 +196,19 @@ def check_bugreport(ctx, iocs, output, list_modules, module, bugreport_path):
 
     if output:
         save_logs(log, os.path.join(output, "logs.txt"))
-        save_hashes(bugreport_path, os.path.join(output, "hashes.txt"))
 
     log.info("Checking an Android Bug Report located at: %s", bugreport_path)
 
     indicators = Indicators(log=log)
     indicators.load_indicators_files(iocs)
+
+    if output:
+        save_info(
+            bugreport_path,
+            os.path.join(output, "infos.json"),
+            True,
+            indicators
+        )
 
     if os.path.isfile(bugreport_path):
         bugreport_format = "zip"
@@ -269,8 +276,16 @@ def check_backup(ctx, iocs, output, backup_path, serial):
 
     log.info("Checking ADB backup located at: %s", backup_path)
 
+    indicators = Indicators(log=log)
+    indicators.load_indicators_files(iocs)
+
     if output:
-        save_hashes(backup_path, os.path.join(output, "hashes.txt"))
+        save_info(
+            backup_path,
+            os.path.join(output, "infos.json"),
+            True,
+            indicators
+        )
 
     if os.path.isfile(backup_path):
         # AB File
@@ -309,9 +324,6 @@ def check_backup(ctx, iocs, output, backup_path, serial):
     else:
         log.critical("Invalid backup path, path should be a folder or an Android Backup (.ab) file")
         ctx.exit(1)
-
-    indicators = Indicators(log=log)
-    indicators.load_indicators_files(iocs)
 
     for module in BACKUP_MODULES:
         m = module(base_folder=backup_path, output_folder=output,

--- a/mvt/common/help.py
+++ b/mvt/common/help.py
@@ -9,6 +9,7 @@ HELP_MSG_IOC = "Path to indicators file (can be invoked multiple time)"
 HELP_MSG_FAST = "Avoid running time/resource consuming features"
 HELP_MSG_LIST_MODULES = "Print list of available modules and exit"
 HELP_MSG_MODULE = "Name of a single module you would like to run instead of all"
+HELP_MSG_HASHES = "Generate hashes of the input file during the analysis (can be slow)"
 
 # Android-specific.
 HELP_MSG_SERIAL = "Specify a device serial number or HOST:PORT connection string"

--- a/mvt/common/module.py
+++ b/mvt/common/module.py
@@ -7,6 +7,9 @@ import csv
 import os
 import re
 import logging
+import typing
+import hashlib
+
 
 import simplejson as json
 
@@ -219,3 +222,33 @@ def save_logs(logger: logging.Logger, log_path: str) -> None:
     fh.setFormatter(formatter)
     logger.addHandler(fh)
     return logger
+
+
+def save_file_hash(path: str, fh: typing.TextIO) -> None:
+    """ Save the file name a the hash of the given file in the file handler
+
+    :param path: path of the file
+    :param fh: file handler of the output file
+    """
+    m = hashlib.sha256()
+    with open(path, "rb") as f:
+        m.update(f.read())
+
+    fh.write(f"{path},{m.hexdigest()}\n")
+
+
+def save_hashes(path: str, log_path: str) -> None:
+    """Save a hash of all the files in a given folder
+
+    :param path: path of the input folder or file
+    :log_path: path of the output file
+    """
+    output_handler = open(log_path, "w+")
+
+    if os.path.isfile(path):
+        save_file_hash(path, output_handler)
+    elif os.path.isdir(path):
+        for (root, dirs, files) in os.walk(path):
+            for f in files:
+                fpath = os.path.join(root, f)
+                save_file_hash(fpath, output_handler)

--- a/mvt/common/module.py
+++ b/mvt/common/module.py
@@ -6,6 +6,7 @@
 import csv
 import os
 import re
+import logging
 
 import simplejson as json
 
@@ -54,6 +55,9 @@ class MVTModule(object):
         self.detected = []
         self.timeline = []
         self.timeline_detected = []
+
+        if output_folder and log:
+            save_logs(log, os.path.join(output_folder, "logs.txt"))
 
     @classmethod
     def from_json(cls, json_path, log=None):
@@ -201,3 +205,17 @@ def save_timeline(timeline, timeline_path):
                 event.get("event"),
                 event.get("data"),
             ])
+
+
+def save_logs(logger: logging.Logger, log_path: str) -> None:
+    """Save logs of the logger into a file
+
+    :param logger: logger object
+    :param log_path: path to store the file
+    """
+    fh = logging.FileHandler(log_path)
+    formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+    fh.setLevel(logging.DEBUG)
+    fh.setFormatter(formatter)
+    logger.addHandler(fh)
+    return logger

--- a/mvt/ios/cli.py
+++ b/mvt/ios/cli.py
@@ -15,7 +15,7 @@ from mvt.common.help import (HELP_MSG_FAST, HELP_MSG_IOC,
                              HELP_MSG_OUTPUT, HELP_MSG_HASHES)
 from mvt.common.indicators import Indicators, download_indicators_files
 from mvt.common.logo import logo
-from mvt.common.module import run_module, save_timeline, save_logs, save_hashes
+from mvt.common.module import run_module, save_timeline, save_logs, save_info
 from mvt.common.options import MutuallyExclusiveOption
 
 from .decrypt import DecryptBackup
@@ -160,12 +160,16 @@ def check_backup(ctx, iocs, output, fast, hashes, backup_path, list_modules, mod
 
     log.info("Checking iTunes backup located at: %s", backup_path)
 
-    if hashes and output:
-        log.info("Generating hashes of backup files, it can take some time")
-        save_hashes(backup_path, os.path.join(output, "hashes.csv"))
-
     indicators = Indicators(log=log)
     indicators.load_indicators_files(iocs)
+
+    if output:
+        save_info(
+            backup_path,
+            os.path.join(output, "info.json"),
+            hashes,
+            indicators
+        )
 
     timeline = []
     timeline_detected = []
@@ -228,12 +232,16 @@ def check_fs(ctx, iocs, output, fast, hashes, dump_path, list_modules, module):
 
     log.info("Checking filesystem dump located at: %s", dump_path)
 
-    if output and hashes:
-        log.info("Generating hashes of the filesystem dump, it can take some time")
-        save_hashes(dump_path, os.path.join(output, "hashes.txt"))
-
     indicators = Indicators(log=log)
     indicators.load_indicators_files(iocs)
+
+    if output:
+        save_info(
+            dump_path,
+            os.path.join(output, "info.json"),
+            hashes,
+            indicators
+        )
 
     timeline = []
     timeline_detected = []

--- a/mvt/ios/cli.py
+++ b/mvt/ios/cli.py
@@ -12,10 +12,10 @@ from rich.prompt import Prompt
 
 from mvt.common.help import (HELP_MSG_FAST, HELP_MSG_IOC,
                              HELP_MSG_LIST_MODULES, HELP_MSG_MODULE,
-                             HELP_MSG_OUTPUT)
+                             HELP_MSG_OUTPUT, HELP_MSG_HASHES)
 from mvt.common.indicators import Indicators, download_indicators_files
 from mvt.common.logo import logo
-from mvt.common.module import run_module, save_timeline, save_logs
+from mvt.common.module import run_module, save_timeline, save_logs, save_hashes
 from mvt.common.options import MutuallyExclusiveOption
 
 from .decrypt import DecryptBackup
@@ -135,11 +135,12 @@ def extract_key(password, backup_path, key_file):
               default=[], help=HELP_MSG_IOC)
 @click.option("--output", "-o", type=click.Path(exists=False), help=HELP_MSG_OUTPUT)
 @click.option("--fast", "-f", is_flag=True, help=HELP_MSG_FAST)
+@click.option("--hashes", "-H", is_flag=True, help=HELP_MSG_HASHES)
 @click.option("--list-modules", "-l", is_flag=True, help=HELP_MSG_LIST_MODULES)
 @click.option("--module", "-m", help=HELP_MSG_MODULE)
 @click.argument("BACKUP_PATH", type=click.Path(exists=True))
 @click.pass_context
-def check_backup(ctx, iocs, output, fast, backup_path, list_modules, module):
+def check_backup(ctx, iocs, output, fast, hashes, backup_path, list_modules, module):
     if list_modules:
         log.info("Following is the list of available check-backup modules:")
         for backup_module in BACKUP_MODULES + MIXED_MODULES:
@@ -158,6 +159,10 @@ def check_backup(ctx, iocs, output, fast, backup_path, list_modules, module):
         save_logs(log, os.path.join(output, "logs.txt"))
 
     log.info("Checking iTunes backup located at: %s", backup_path)
+
+    if hashes and output:
+        log.info("Generating hashes of backup files, it can take some time")
+        save_hashes(backup_path, os.path.join(output, "hashes.csv"))
 
     indicators = Indicators(log=log)
     indicators.load_indicators_files(iocs)
@@ -198,11 +203,12 @@ def check_backup(ctx, iocs, output, fast, backup_path, list_modules, module):
               default=[], help=HELP_MSG_IOC)
 @click.option("--output", "-o", type=click.Path(exists=False), help=HELP_MSG_OUTPUT)
 @click.option("--fast", "-f", is_flag=True, help=HELP_MSG_FAST)
+@click.option("--hashes", "-H", is_flag=True, help=HELP_MSG_HASHES)
 @click.option("--list-modules", "-l", is_flag=True, help=HELP_MSG_LIST_MODULES)
 @click.option("--module", "-m", help=HELP_MSG_MODULE)
 @click.argument("DUMP_PATH", type=click.Path(exists=True))
 @click.pass_context
-def check_fs(ctx, iocs, output, fast, dump_path, list_modules, module):
+def check_fs(ctx, iocs, output, fast, hashes, dump_path, list_modules, module):
     if list_modules:
         log.info("Following is the list of available check-fs modules:")
         for fs_module in FS_MODULES + MIXED_MODULES:
@@ -221,6 +227,10 @@ def check_fs(ctx, iocs, output, fast, dump_path, list_modules, module):
         save_logs(log, os.path.join(output, "logs.txt"))
 
     log.info("Checking filesystem dump located at: %s", dump_path)
+
+    if output and hashes:
+        log.info("Generating hashes of the filesystem dump, it can take some time")
+        save_hashes(dump_path, os.path.join(output, "hashes.txt"))
 
     indicators = Indicators(log=log)
     indicators.load_indicators_files(iocs)

--- a/mvt/ios/cli.py
+++ b/mvt/ios/cli.py
@@ -15,7 +15,7 @@ from mvt.common.help import (HELP_MSG_FAST, HELP_MSG_IOC,
                              HELP_MSG_OUTPUT)
 from mvt.common.indicators import Indicators, download_indicators_files
 from mvt.common.logo import logo
-from mvt.common.module import run_module, save_timeline
+from mvt.common.module import run_module, save_timeline, save_logs
 from mvt.common.options import MutuallyExclusiveOption
 
 from .decrypt import DecryptBackup
@@ -147,14 +147,17 @@ def check_backup(ctx, iocs, output, fast, backup_path, list_modules, module):
 
         return
 
-    log.info("Checking iTunes backup located at: %s", backup_path)
-
     if output and not os.path.exists(output):
         try:
             os.makedirs(output)
         except Exception as e:
             log.critical("Unable to create output folder %s: %s", output, e)
             ctx.exit(1)
+
+    if output:
+        save_logs(log, os.path.join(output, "logs.txt"))
+
+    log.info("Checking iTunes backup located at: %s", backup_path)
 
     indicators = Indicators(log=log)
     indicators.load_indicators_files(iocs)
@@ -207,14 +210,17 @@ def check_fs(ctx, iocs, output, fast, dump_path, list_modules, module):
 
         return
 
-    log.info("Checking filesystem dump located at: %s", dump_path)
-
     if output and not os.path.exists(output):
         try:
             os.makedirs(output)
         except Exception as e:
             log.critical("Unable to create output folder %s: %s", output, e)
             ctx.exit(1)
+
+    if output:
+        save_logs(log, os.path.join(output, "logs.txt"))
+
+    log.info("Checking filesystem dump located at: %s", dump_path)
 
     indicators = Indicators(log=log)
     indicators.load_indicators_files(iocs)

--- a/mvt/ios/modules/mixed/whatsapp.py
+++ b/mvt/ios/modules/mixed/whatsapp.py
@@ -3,7 +3,6 @@
 # Use of this software is governed by the MVT License 1.1 that can be found at
 #   https://license.mvt.re/1.1/
 
-import logging
 import sqlite3
 
 from mvt.common.utils import (check_for_links, convert_mactime_to_unix,
@@ -11,7 +10,6 @@ from mvt.common.utils import (check_for_links, convert_mactime_to_unix,
 
 from ..base import IOSExtraction
 
-log = logging.getLogger(__name__)
 
 WHATSAPP_BACKUP_IDS = [
     "7c7fba66680ef796b916b067077cc246adacf01d",
@@ -56,7 +54,7 @@ class Whatsapp(IOSExtraction):
     def run(self):
         self._find_ios_database(backup_ids=WHATSAPP_BACKUP_IDS,
                                 root_paths=WHATSAPP_ROOT_PATHS)
-        log.info("Found WhatsApp database at path: %s", self.file_path)
+        self.log.info("Found WhatsApp database at path: %s", self.file_path)
 
         conn = sqlite3.connect(self.file_path)
         cur = conn.cursor()
@@ -108,4 +106,4 @@ class Whatsapp(IOSExtraction):
         cur.close()
         conn.close()
 
-        log.info("Extracted a total of %d WhatsApp messages containing links", len(self.results))
+        self.log.info("Extracted a total of %d WhatsApp messages containing links", len(self.results))


### PR DESCRIPTION
Hi,

This PR adds two features :
* When an output is given, it logs the execution timeline in `logs.txt` in the output folder
* It generates a hash of the input files in a `hashes.txt` file (optional on large set of data to avoid slowing down the process)