### PR TITLE
Fixed cmd_download_apks serial connection bug

### DIFF
--- a/mvt/android/cmd_download_apks.py
+++ b/mvt/android/cmd_download_apks.py
@@ -115,6 +115,7 @@ class DownloadAPKs(AndroidExtraction):
 
         m = Packages()
         m.log = self.log
+        m.serial = self.serial
         m.run()
 
         self.packages = m.results


### PR DESCRIPTION
I tried to download apks from my smartphone via serial but it didn't work so I noticed that the Package object was not receiving the string serial, so when _adb_connect() was called from Packages run method the serial variable was set to None and for this reason the connection was not established.