### PR TITLE
Extract all messages from SMS and WhatsApp

### DIFF
--- a/docs/android/backup.md
+++ b/docs/android/backup.md
@@ -24,7 +24,7 @@ Some recent phones will enforce the utilisation of a password to encrypt the bac
 
 ## Unpack and check the backup
 
-MVT includes a partial implementation of the Android Backup parsing, because of the implementation difference in the compression algorithm between Java and Python. The `-nocompress` option passed to adb in the section above allows to avoid this issue. You can analyse and extract SMSs containing links from the backup directly with MVT:
+MVT includes a partial implementation of the Android Backup parsing, because of the implementation difference in the compression algorithm between Java and Python. The `-nocompress` option passed to adb in the section above allows to avoid this issue. You can analyse and extract SMSs from the backup directly with MVT:
 
 ```bash
 $ mvt-android check-backup --output /path/to/results/ /path/to/backup.ab
@@ -32,7 +32,7 @@ $ mvt-android check-backup --output /path/to/results/ /path/to/backup.ab
          INFO     [mvt.android.modules.backup.sms] Running module SMS...
          INFO     [mvt.android.modules.backup.sms] Processing SMS backup file at
                   apps/com.android.providers.telephony/d_f/000000_sms_backup
-         INFO     [mvt.android.modules.backup.sms] Extracted a total of 64 SMS messages containing links
+         INFO     [mvt.android.modules.backup.sms] Extracted a total of 64 SMS messages
 ```
 
 If the backup is encrypted, MVT will prompt you to enter the password.
@@ -52,4 +52,4 @@ If the backup is encrypted, ABE will prompt you to enter the password.
 
 Alternatively, [ab-decrypt](https://github.com/joernheissler/ab-decrypt) can be used for that purpose.
 
-You can then extract SMSs containing links with MVT by passing the folder path as parameter instead of the `.ab` file: `mvt-android check-backup --output /path/to/results/ /path/to/backup/` (the path to backup given should be the folder containing the `apps` folder).
+You can then extract SMSs with MVT by passing the folder path as parameter instead of the `.ab` file: `mvt-android check-backup --output /path/to/results/ /path/to/backup/` (the path to backup given should be the folder containing the `apps` folder).

--- a/docs/ios/records.md
+++ b/docs/ios/records.md
@@ -7,7 +7,7 @@ In this page you can find a (reasonably) up-to-date breakdown of the files creat
 ### `analytics.json`
 
 !!! info "Availability"
-    Backup (if encrypted): :material-close:  
+    Backup (if encrypted): :material-close:
     Full filesystem dump: :material-check:
 
 This JSON file is created by mvt-ios' `Analytics` module. The module extracts records from the plists inside the SQLite databases located at *private/var/Keychains/Analytics/\*.db*, which contain various analytics information regarding networking, certificate-pinning, TLS, etc. failures.
@@ -19,7 +19,7 @@ If indicators are provided through the command-line, processes and domains are c
 ### `backup_info.json`
 
 !!! info "Availability"
-    Backup: :material-check:  
+    Backup: :material-check:
     Full filesystem dump: :material-close:
 
 This JSON file is created by mvt-ios' `BackupInfo` module. The module extracts some details about the backup and the device, such as name, phone number, IMEI, product type and version.
@@ -29,7 +29,7 @@ This JSON file is created by mvt-ios' `BackupInfo` module. The module extracts s
 ### `cache_files.json`
 
 !!! info "Availability"
-    Backup: :material-close:  
+    Backup: :material-close:
     Full filesystem dump: :material-check:
 
 This JSON file is created by mvt-ios' `CacheFiles` module. The module extracts records from all SQLite database files stored on disk with the name *Cache.db*. These databases typically contain data from iOS' [internal URL caching](https://developer.apple.com/documentation/foundation/nsurlcache). Through this module you might be able to recover records of HTTP requests and responses performed my applications as well as system services, that would otherwise be unavailable. For example, you might see HTTP requests part of an exploitation chain performed by an iOS service attempting to download a first stage malicious payload.
@@ -41,7 +41,7 @@ If indicators are provided through the command-line, they are checked against th
 ### `calls.json`
 
 !!! info "Availability"
-    Backup (if encrypted): :material-check:  
+    Backup (if encrypted): :material-check:
     Full filesystem dump: :material-check:
 
 This JSON file is created by mvt-ios' `Calls` module. The module extracts records from a SQLite database located at */private/var/mobile/Library/CallHistoryDB/CallHistory.storedata*, which contains records of incoming and outgoing calls, including from messaging apps such as WhatsApp or Skype.
@@ -51,7 +51,7 @@ This JSON file is created by mvt-ios' `Calls` module. The module extracts record
 ### `chrome_favicon.json`
 
 !!! info "Availability"
-    Backup: :material-check:  
+    Backup: :material-check:
     Full filesystem dump: :material-check:
 
 This JSON file is created by mvt-ios' `ChromeFavicon` module. The module extracts records from a SQLite database located at */private/var/mobile/Containers/Data/Application/\*/Library/Application Support/Google/Chrome/Default/Favicons*, which contains a mapping of favicons' URLs and the visited URLs which loaded them.
@@ -63,7 +63,7 @@ If indicators are provided through the command-line, they are checked against bo
 ### `chrome_history.json`
 
 !!! info "Availability"
-    Backup: :material-check:  
+    Backup: :material-check:
     Full filesystem dump: :material-check:
 
 This JSON file is created by mvt-ios' `ChromeHistory` module. The module extracts records from a SQLite database located at */private/var/mobile/Containers/Data/Application/\*/Library/Application Support/Google/Chrome/Default/History*, which contains a history of URL visits.
@@ -75,7 +75,7 @@ If indicators are provided through the command-line, they are checked against th
 ### `configuration_profiles.json`
 
 !!! info "Availability"
-    Backup: :material-check:  
+    Backup: :material-check:
     Full filesystem dump: :material-close:
 
 This JSON file is created by mvt-ios' `ConfigurationProfiles` module. The module extracts details about iOS configuration profiles that have been installed on the device. These should include both default iOS as well as third-party profiles.
@@ -87,7 +87,7 @@ If indicators are provided through the command-line, they are checked against th
 ### `contacts.json`
 
 !!! info "Availability"
-    Backup: :material-check:  
+    Backup: :material-check:
     Full filesystem dump: :material-check:
 
 This JSON file is created by mvt-ios' `Contacts` module. The module extracts records from a SQLite database located at */private/var/mobile/Library/AddressBook/AddressBook.sqlitedb*, which contains records from the phone's address book. While this database obviously would not contain any malicious indicators per se, you might want to use it to compare records from other apps (such as iMessage, SMS, etc.) to filter those originating from unknown origins.
@@ -97,7 +97,7 @@ This JSON file is created by mvt-ios' `Contacts` module. The module extracts rec
 ### `firefox_favicon.json`
 
 !!! info "Availability"
-    Backup: :material-check:  
+    Backup: :material-check:
     Full filesystem dump: :material-check:
 
 This JSON file is created by mvt-ios' `FirefoxFavicon` module. The module extracts records from a SQLite database located at */private/var/mobile/profile.profile/browser.db*, which contains a mapping of favicons' URLs and the visited URLs which loaded them.
@@ -109,7 +109,7 @@ If indicators are provided through the command-line, they are checked against bo
 ### `firefox_history.json`
 
 !!! info "Availability"
-    Backup: :material-check:  
+    Backup: :material-check:
     Full filesystem dump: :material-check:
 
 This JSON file is created by mvt-ios' `FirefoxHistory` module. The module extracts records from a SQLite database located at */private/var/mobile/profile.profile/browser.db*, which contains a history of URL visits.
@@ -121,7 +121,7 @@ If indicators are provided through the command-line, they are checked against th
 ### `id_status_cache.json`
 
 !!! info "Availability"
-    Backup (before iOS 14.7): :material-check:  
+    Backup (before iOS 14.7): :material-check:
     Full filesystem dump: :material-check:
 
 This JSON file is created by mvt-ios' `IDStatusCache` module. The module extracts records from a plist file located at */private/var/mobile/Library/Preferences/com.apple.identityservices.idstatuscache.plist*, which contains a cache of Apple user ID authentication. This chance will indicate when apps like Facetime and iMessage first established contacts with other registered Apple IDs. This is significant because it might contain traces of malicious accounts involved in exploitation of those apps.
@@ -133,7 +133,7 @@ Starting from iOS 14.7.0, this file is empty or absent.
 ### `shortcuts.json`
 
 !!! info "Availability"
-    Backup: :material-check:  
+    Backup: :material-check:
     Full filesystem dump: :material-check:
 
 This JSON file is created by mvt-ios' `Shortcuts` module. The module extracts records from an SQLite database located at */private/var/mobile/Library/Shortcuts/Shortcuts.sqlite*, which contains records about the Shortcuts application. Shortcuts are a built-in iOS feature which allows users to automation certain actions on their device. In some cases the legitimate Shortcuts app may be abused by spyware to maintain persistence on an infected devices.
@@ -143,7 +143,7 @@ This JSON file is created by mvt-ios' `Shortcuts` module. The module extracts re
 ### `interaction_c.json`
 
 !!! info "Availability"
-    Backup (if encrypted): :material-check:  
+    Backup (if encrypted): :material-check:
     Full filesystem dump: :material-check:
 
 This JSON file is created by mvt-ios' `InteractionC` module. The module extracts records from a SQLite database located at */private/var/mobile/Library/CoreDuet/People/interactionC.db*, which contains details about user interactions with installed apps.
@@ -153,7 +153,7 @@ This JSON file is created by mvt-ios' `InteractionC` module. The module extracts
 ### `locationd_clients.json`
 
 !!! info "Availability"
-    Backup: :material-check:  
+    Backup: :material-check:
     Full filesystem dump: :material-check:
 
 This JSON file is created by mvt-ios' `LocationdClients` module. The module extracts records from a plist file located at */private/var/mobile/Library/Caches/locationd/clients.plist*, which contains a cache of apps which requested access to location services.
@@ -163,7 +163,7 @@ This JSON file is created by mvt-ios' `LocationdClients` module. The module extr
 ### `manifest.json`
 
 !!! info "Availability"
-    Backup: :material-check:  
+    Backup: :material-check:
     Full filesystem dump: :material-close:
 
 This JSON file is created by mvt-ios' `Manifest` module. The module extracts records from the SQLite database *Manifest.db* contained in iTunes backups, and which indexes the locally backed-up files to the original paths on the iOS device.
@@ -175,7 +175,7 @@ If indicators are provided through the command-line, they are checked against th
 ### `os_analytics_ad_daily.json`
 
 !!! info "Availability"
-    Backup: :material-check:  
+    Backup: :material-check:
     Full filesystem dump: :material-check:
 
 This JSON file is created by mvt-ios' `OSAnalyticsADDaily` module. The module extracts records from a plist located *private/var/mobile/Library/Preferences/com.apple.osanalytics.addaily.plist*, which contains a history of data usage by processes running on the system. Besides the network statistics, these records are particularly important because they might show traces of malicious process executions and the relevant timeframe.
@@ -187,7 +187,7 @@ If indicators are provided through the command-line, they are checked against th
 ### `datausage.json`
 
 !!! info "Availability"
-    Backup: :material-check:  
+    Backup: :material-check:
     Full filesystem dump: :material-check:
 
 This JSON file is created by mvt-ios' `Datausage` module. The module extracts records from a SQLite database located */private/var/wireless/Library/Databases/DataUsage.sqlite*, which contains a history of network data usage by processes running on the system. It does not log network traffic through WiFi (the fields `WIFI_IN` and `WIFI_OUT` are always empty), and the `WWAN_IN` and `WWAN_OUT` fields are stored in bytes. Besides the network statistics, these records are particularly important because they might show traces of malicious process executions and the relevant timeframe. In particular, processes which do not have a valid bundle ID might require particular attention.
@@ -199,7 +199,7 @@ If indicators are provided through the command-line, they are checked against th
 ### `netusage.json`
 
 !!! info "Availability"
-    Backup: :material-close:  
+    Backup: :material-close:
     Full filesystem dump: :material-check:
 
 This JSON file is created by mvt-ios' `Netusage` module. The module extracts records from a SQLite database located */private/var/networkd/netusage.sqlite*, which contains a history of data usage by processes running on the system. Besides the network statistics, these records are particularly important because they might show traces of malicious process executions and the relevant timeframe. In particular, processes which do not have a valid bundle ID might require particular attention.
@@ -211,7 +211,7 @@ If indicators are provided through the command-line, they are checked against th
 ### `profile_events.json`
 
 !!! info "Availability"
-    Backup: :material-check:  
+    Backup: :material-check:
     Full filesystem dump: :material-close:
 
 This JSON file is created by mvt-ios' `ProfileEvents` module. The module extracts a timeline of configuration profile operations. For example, it should indicate when a new profile was installed from the Settings app, or when one was removed.
@@ -221,7 +221,7 @@ This JSON file is created by mvt-ios' `ProfileEvents` module. The module extract
 ### `safari_browser_state.json`
 
 !!! info "Availability"
-    Backup (if encrypted): :material-check:  
+    Backup (if encrypted): :material-check:
     Full filesystem dump: :material-check:
 
 This JSON file is created by mvt-ios' `SafariBrowserState` module. The module extracts records from the SQLite databases located at */private/var/mobile/Library/Safari/BrowserState.db* or */private/var/mobile/Containers/Data/Application/\*/Library/Safari/BrowserState.db*, which contain records of opened tabs.
@@ -233,7 +233,7 @@ If indicators are provided through the command-line, they are checked against th
 ### `safari_favicon.json`
 
 !!! info "Availability"
-    Backup: :material-close:  
+    Backup: :material-close:
     Full filesystem dump: :material-check:
 
 This JSON file is created by mvt-ios' `SafariFavicon` module. The module extracts records from the SQLite databases located at */private/var/mobile/Library/Image Cache/Favicons/Favicons.db* or */private/var/mobile/Containers/Data/Application/\*/Library/Image Cache/Favicons/Favicons.db*, which contain mappings of favicons' URLs and the visited URLs which loaded them.
@@ -245,7 +245,7 @@ If indicators are provided through the command-line, they are checked against bo
 ### `safari_history.json`
 
 !!! info "Availability"
-    Backup (if encrypted): :material-check:  
+    Backup (if encrypted): :material-check:
     Full filesystem dump: :material-check:
 
 This JSON file is created by mvt-ios' `SafariHistory` module. The module extracts records from the SQLite databases located at */private/var/mobile/Library/Safari/History.db* or */private/var/mobile/Containers/Data/Application/\*/Library/Safari/History.db*, which contain a history of URL visits.
@@ -257,7 +257,7 @@ If indicators are provided through the command-line, they are checked against th
 ### `shutdown_log.json`
 
 !!! info "Availability"
-    Backup (if encrypted): :material-close:  
+    Backup (if encrypted): :material-close:
     Full filesystem dump: :material-check:
 
 This JSON file is created by mvt-ios' `ShutdownLog` module. The module extracts records from the shutdown log located at *private/var/db/diagnostics/shutdown.log*. When shutting down an iPhone, a SIGTERM will be sent to all processes runnning. The `shutdown.log` file will log any process (with its pid and path) that did not shut down after the SIGTERM was sent.
@@ -269,10 +269,10 @@ If indicators are provided through the command-line, they are checked against th
 ### `sms.json`
 
 !!! info "Availability"
-    Backup: :material-check:  
+    Backup: :material-check:
     Full filesystem dump: :material-check:
 
-This JSON file is created by mvt-ios' `SMS` module. The module extracts a list of SMS messages containing HTTP links from the SQLite database located at */private/var/mobile/Library/SMS/sms.db*.
+This JSON file is created by mvt-ios' `SMS` module. The module extracts a list of SMS messages from the SQLite database located at */private/var/mobile/Library/SMS/sms.db*.
 
 If indicators are provided through the command-line, they are checked against the extracted HTTP links. Any matches are stored in *sms_detected.json*.
 
@@ -281,7 +281,7 @@ If indicators are provided through the command-line, they are checked against th
 ### `sms_attachments.json`
 
 !!! info "Availability"
-    Backup: :material-check:  
+    Backup: :material-check:
     Full filesystem dump: :material-check:
 
 This JSON file is created by mvt-ios' `SMSAttachments` module. The module extracts details about attachments sent via SMS or iMessage from the same database used by the `SMS` module. These records might be useful to indicate unique patterns that might be indicative of exploitation attempts leveraging potential vulnerabilities in file format parsers or other forms of file handling by the Messages app.
@@ -291,7 +291,7 @@ This JSON file is created by mvt-ios' `SMSAttachments` module. The module extrac
 ### `tcc.json`
 
 !!! info "Availability"
-    Backup: :material-check:  
+    Backup: :material-check:
     Full filesystem dump: :material-check:
 
 This JSON file is created by mvt-ios' `TCC` module. The module extracts records from a SQLite database located at */private/var/mobile/Library/TCC/TCC.db*, which contains a list of which services such as microphone, camera, or location, apps have been granted or denied access to.
@@ -301,7 +301,7 @@ This JSON file is created by mvt-ios' `TCC` module. The module extracts records 
 ### `version_history.json`
 
 !!! info "Availability"
-    Backup: :material-close:  
+    Backup: :material-close:
     Full filesystem dump: :material-check:
 
 This JSON file is created by mvt-ios' `IOSVersionHistory` module. The module extracts records of iOS software updates from analytics plist files located at */private/var/db/analyticsd/Analytics-Journal-\*.ips*.
@@ -311,7 +311,7 @@ This JSON file is created by mvt-ios' `IOSVersionHistory` module. The module ext
 ### `webkit_indexeddb.json`
 
 !!! info "Availability"
-    Backup: :material-close:  
+    Backup: :material-close:
     Full filesystem dump: :material-check:
 
 This JSON file is created by mvt-ios' `WebkitIndexedDB` module. The module extracts a list of file and folder names located at the following path */private/var/mobile/Containers/Data/Application/\*/Library/WebKit/WebsiteData/IndexedDB*, which contains IndexedDB files created by any app installed on the device.
@@ -323,7 +323,7 @@ If indicators are provided through the command-line, they are checked against th
 ### `webkit_local_storage.json`
 
 !!! info "Availability"
-    Backup: :material-close:  
+    Backup: :material-close:
     Full filesystem dump: :material-check:
 
 This JSON file is created by mvt-ios' `WebkitLocalStorage` module. The module extracts a list of file and folder names located at the following path */private/var/mobile/Containers/Data/Application/\*/Library/WebKit/WebsiteData/LocalStorage/*, which contains local storage files created by any app installed on the device.
@@ -335,7 +335,7 @@ If indicators are provided through the command-line, they are checked against th
 ### `webkit_resource_load_statistics.json`
 
 !!! info "Availability"
-    Backup: :material-check:  
+    Backup: :material-check:
     Full filesystem dump: :material-check:
 
 This JSON file is created by mvt-ios `WebkitResourceLoadStatistics` module. The module extracts records from available WebKit ResourceLoadStatistics *observations.db* SQLite3 databases. These records should indicate domain names contacted by apps, including a timestamp.
@@ -347,7 +347,7 @@ If indicators are provided through the command-line, they are checked against th
 ### `webkit_safari_view_service.json`
 
 !!! info "Availability"
-    Backup: :material-close:  
+    Backup: :material-close:
     Full filesystem dump: :material-check:
 
 This JSON file is created by mvt-ios' `WebkitSafariViewService` module. The module extracts a list of file and folder names located at the following path */private/var/mobile/Containers/Data/Application/\*/SystemData/com.apple.SafariViewService/Library/WebKit/WebsiteData/*, which contains files cached by SafariVewService.
@@ -359,7 +359,7 @@ If indicators are provided through the command-line, they are checked against th
 ### `webkit_session_resource_log.json`
 
 !!! info "Availability"
-    Backup: :material-check:  
+    Backup: :material-check:
     Full filesystem dump: :material-check:
 
 This JSON file is created by mvt-ios' `WebkitSessionResourceLog` module. The module extracts records from plist files with the name *full_browsing_session_resourceLog.plist*, which contain records of resources loaded by different domains visited.
@@ -371,10 +371,10 @@ If indicators are provided through the command-line, they are checked against th
 ### `whatsapp.json`
 
 !!! info "Availability"
-    Backup: :material-check:  
+    Backup: :material-check:
     Full filesystem dump: :material-check:
 
-This JSON file is created by mvt-ios' `WhatsApp` module. The module extracts a list of WhatsApp messages containing HTTP links from the SQLite database located at *private/var/mobile/Containers/Shared/AppGroup/\*/ChatStorage.sqlite*.
+This JSON file is created by mvt-ios' `WhatsApp` module. The module extracts a list of WhatsApp messages from the SQLite database located at *private/var/mobile/Containers/Shared/AppGroup/\*/ChatStorage.sqlite*.
 
 If indicators are provided through the command-line, they are checked against the extracted HTTP links. Any matches are stored in *whatsapp_detected.json*.
 

--- a/mvt/android/modules/backup/sms.py
+++ b/mvt/android/modules/backup/sms.py
@@ -8,6 +8,7 @@ from typing import Optional
 
 from mvt.android.modules.backup.base import BackupExtraction
 from mvt.android.parsers.backup import parse_sms_file
+from mvt.common.utils import check_for_links
 
 
 class SMS(BackupExtraction):
@@ -34,7 +35,11 @@ class SMS(BackupExtraction):
             if "body" not in message:
                 continue
 
-            if self.indicators.check_domains(message["links"]):
+            message_links = message.get("links", [])
+            if message_links == []:
+                message_links = check_for_links(message.get("text", ""))
+
+            if self.indicators.check_domains(message_links):
                 self.detected.append(message)
 
     def run(self) -> None:
@@ -50,5 +55,5 @@ class SMS(BackupExtraction):
             data = self._get_file_content(file)
             self.results.extend(parse_sms_file(data))
 
-        self.log.info("Extracted a total of %d SMS & MMS messages containing links",
+        self.log.info("Extracted a total of %d SMS & MMS messages",
                       len(self.results))

--- a/mvt/android/parsers/backup.py
+++ b/mvt/android/parsers/backup.py
@@ -218,10 +218,9 @@ def parse_sms_file(data):
         entry["isodate"] = convert_unix_to_iso(int(entry["date"]) / 1000)
         entry["direction"] = ("sent" if int(entry["date_sent"]) else "received")
 
-        # If we find links in the messages or if they are empty we add them to
-        # the list.
+        # Extract links from the body
         if message_links or entry["body"].strip() == "":
             entry["links"] = message_links
-            res.append(entry)
+        res.append(entry)
 
     return res

--- a/mvt/ios/modules/mixed/whatsapp.py
+++ b/mvt/ios/modules/mixed/whatsapp.py
@@ -112,14 +112,13 @@ class Whatsapp(IOSExtraction):
                         or link.startswith("https://mmg.whatsapp.net/")):
                     filtered_links.append(link)
 
-            # If we find messages with links, or if there's an empty message
-            # we add it to the results list.
+            # Add all the links found to the record
             if filtered_links or (message.get("ZTEXT") or "").strip() == "":
                 message["links"] = list(set(filtered_links))
-                self.results.append(message)
+            self.results.append(message)
 
         cur.close()
         conn.close()
 
-        self.log.info("Extracted a total of %d WhatsApp messages containing links",
+        self.log.info("Extracted a total of %d WhatsApp messages",
                       len(self.results))


### PR DESCRIPTION
One initial decision with MVT was to only extract messages from SMS and WhatsApp there were containing links, but this is getting a problem in some investigation because messages from an attack could be missed during manual review. 

Here is a MR that change that and extract all messages.