### PR TITLE
Fix error when creating report: csv.Error

### DIFF
--- a/mvt/common/module.py
+++ b/mvt/common/module.py
@@ -214,7 +214,7 @@ def save_timeline(timeline: list, timeline_path: str) -> None:
     """
     with open(timeline_path, "a+", encoding="utf-8") as handle:
         csvoutput = csv.writer(handle, delimiter=",", quotechar="\"",
-                               quoting=csv.QUOTE_ALL)
+                               quoting=csv.QUOTE_ALL, escapechar='\\')
         csvoutput.writerow(["UTC Timestamp", "Plugin", "Event", "Description"])
 
         for event in sorted(timeline, key=lambda x: x["timestamp"]


### PR DESCRIPTION
Crashing when trying to create "timeline.csv" file, because some special character. 

The error was the following

```
Traceback (most recent call last):
  File "/Users/COMPUTER/miniforge3/bin/mvt-android", line 8, in <module>
    sys.exit(cli())
  File "/Users/COMPUTER/miniforge3/lib/python3.10/site-packages/click/core.py", line 1130, in __call__
    return self.main(*args, **kwargs)
  File "/Users/COMPUTER/miniforge3/lib/python3.10/site-packages/click/core.py", line 1055, in main
    rv = self.invoke(ctx)
  File "/Users/COMPUTER/miniforge3/lib/python3.10/site-packages/click/core.py", line 1657, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/Users/COMPUTER/miniforge3/lib/python3.10/site-packages/click/core.py", line 1404, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/Users/COMPUTER/miniforge3/lib/python3.10/site-packages/click/core.py", line 760, in invoke
    return __callback(*args, **kwargs)
  File "/Users/COMPUTER/miniforge3/lib/python3.10/site-packages/click/decorators.py", line 26, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/Users/COMPUTER/miniforge3/lib/python3.10/site-packages/mvt/android/cli.py", line 126, in check_adb
    cmd.run()
  File "/Users/COMPUTER/miniforge3/lib/python3.10/site-packages/mvt/common/command.py", line 199, in run
    self._store_timeline()
  File "/Users/COMPUTER/miniforge3/lib/python3.10/site-packages/mvt/common/command.py", line 85, in _store_timeline
    save_timeline(self.timeline,
  File "/Users/COMPUTER/miniforge3/lib/python3.10/site-packages/mvt/common/module.py", line 222, in save_timeline
    csvoutput.writerow([
_csv.Error: need to escape, but no escapechar set
(base)
```