### PR TITLE
Improve appops parsing in dumpsys

### DIFF
--- a/mvt/android/parsers/dumpsys.py
+++ b/mvt/android/parsers/dumpsys.py
@@ -339,6 +339,17 @@ def parse_dumpsys_appops(output: str) -> List[Dict[str, Any]]:
 
         if line.startswith("  Uid "):
             uid = line[6:-1]
+            if entry:
+                perm["entries"].append(entry)
+                entry = {}
+
+            if package:
+                if perm:
+                    package["permissions"].append(perm)
+
+                perm = {}
+                results.append(package)
+            package = {}
             continue
 
         if line.startswith("    Package "):
@@ -360,7 +371,7 @@ def parse_dumpsys_appops(output: str) -> List[Dict[str, Any]]:
             }
             continue
 
-        if line.startswith("      ") and line[6] != " ":
+        if package and line.startswith("      ") and line[6] != " ":
             if entry:
                 perm["entries"].append(entry)
                 entry = {}


### PR DESCRIPTION
Without this change the package doesn't get properly reset when a new user starts.

See for example in this excerpt:

```
 1 |    Package com.android.bluetooth:
 2 |      READ_CONTACTS (allow):
 3 |        null=[
 4 |          Access: [pers-s] 2022-04-22 13:24:17.577 (-277d5h22m53s447ms)
 5 |        ]
 6 |      WAKE_LOCK (allow):
 7 |        null=[
 8 |          Access: [pers-s] 2023-01-24 17:45:49.712 (-1m21s312ms) duration=+3ms
 9 |        ]
10 |      GET_USAGE_STATS (default):
11 |        null=[
12 |          Reject: [pers-s]2022-04-22 13:23:53.964 (-277d5h23m17s60ms)
13 |        ]
14 |      BLUETOOTH_CONNECT (allow):
15 |        null=[
16 |          Access: [pers-s] 2022-04-22 13:23:53.988 (-277d5h23m17s36ms)
17 |        ]
18 |  Uid 1027:
19 |    state=pers
20 |    capability=LCMN
21 |    appWidgetVisible=false
22 |      LEGACY_STORAGE: mode=ignore
23 |    Package com.android.nfc:
24 |      WAKE_LOCK (allow):
25 |        null=[
26 |          Access: [pers-s] 2022-04-22 13:23:54.633 (-277d5h23m16s391ms) duration=+1s73ms
27 |        ]
```

Here the package "com.android.bluetooth" is not reset when in line 18, so when "LEGACY_STORAGE:" in line 22 is encountered, it's added as another permission to "com.android.bluetooth" with "access" set to "ode=igno".

This PR fixes that by resetting the package whenever a new Uid is encountered.