### PR TITLE
Add GitHub Annotions to ruff output

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -16,12 +16,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.8', '3.9', '3.10']
+        python-version: ['3.8', '3.9', '3.10', '3.11']
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.8', '3.9', '3.10']  # , '3.11']
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -6,16 +6,11 @@ jobs:
     name: Ruff syntax check
     runs-on: ubuntu-latest
     steps:
-      - name: Setup Python
-        uses: actions/setup-python@v1
-        with:
-          python-version: 3.9
-          architecture: x64
       - name: Checkout
         uses: actions/checkout@master
       - name: Install Dependencies
         run: |
-          pip install ruff
+          pip install --user ruff
       - name: ruff
         run: |
-          ruff check .
+          ruff --format=github .

--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -1,6 +1,9 @@
 name: Ruff
-on: [push]
-
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
 jobs:
   ruff_py3:
     name: Ruff syntax check


### PR DESCRIPTION
The ruff Action uses minimal steps to run in ~5 seconds, rapidly providing intuitive GitHub Annotations to contributors.

![image](https://user-images.githubusercontent.com/3709715/223758136-afc386d2-70aa-4eff-953a-2c2d82ceea23.png)