### PR TITLE
Add a module_options parameter to pass data from CLI to modules

### DIFF
--- a/mvt/android/cli.py
+++ b/mvt/android/cli.py
@@ -145,12 +145,14 @@ def download_apks(ctx, all_apks, virustotal, output, from_file, serial, verbose)
 @click.pass_context
 def check_adb(ctx, serial, iocs, output, fast, list_modules, module, verbose):
     set_verbose_logging(verbose)
+    module_options = {"fast_mode": fast}
+
     cmd = CmdAndroidCheckADB(
         results_path=output,
         ioc_files=iocs,
         module_name=module,
         serial=serial,
-        fast_mode=fast,
+        module_options=module_options,
     )
 
     if list_modules:

--- a/mvt/android/cmd_check_adb.py
+++ b/mvt/android/cmd_check_adb.py
@@ -21,7 +21,7 @@ class CmdAndroidCheckADB(Command):
         ioc_files: Optional[list] = None,
         module_name: Optional[str] = None,
         serial: Optional[str] = None,
-        fast_mode: bool = False,
+        module_options: Optional[dict] = None,
     ) -> None:
         super().__init__(
             target_path=target_path,
@@ -29,7 +29,7 @@ class CmdAndroidCheckADB(Command):
             ioc_files=ioc_files,
             module_name=module_name,
             serial=serial,
-            fast_mode=fast_mode,
+            module_options=module_options,
             log=log,
         )
 

--- a/mvt/android/cmd_check_androidqf.py
+++ b/mvt/android/cmd_check_androidqf.py
@@ -21,7 +21,7 @@ class CmdAndroidCheckAndroidQF(Command):
         ioc_files: Optional[list] = None,
         module_name: Optional[str] = None,
         serial: Optional[str] = None,
-        fast_mode: bool = False,
+        module_options: Optional[dict] = None,
         hashes: bool = False,
     ) -> None:
         super().__init__(
@@ -30,7 +30,7 @@ class CmdAndroidCheckAndroidQF(Command):
             ioc_files=ioc_files,
             module_name=module_name,
             serial=serial,
-            fast_mode=fast_mode,
+            module_options=module_options,
             hashes=hashes,
             log=log,
         )

--- a/mvt/android/cmd_check_backup.py
+++ b/mvt/android/cmd_check_backup.py
@@ -35,7 +35,7 @@ class CmdAndroidCheckBackup(Command):
         ioc_files: Optional[list] = None,
         module_name: Optional[str] = None,
         serial: Optional[str] = None,
-        fast_mode: bool = False,
+        module_options: Optional[dict] = None,
         hashes: bool = False,
     ) -> None:
         super().__init__(
@@ -44,7 +44,7 @@ class CmdAndroidCheckBackup(Command):
             ioc_files=ioc_files,
             module_name=module_name,
             serial=serial,
-            fast_mode=fast_mode,
+            module_options=module_options,
             hashes=hashes,
             log=log,
         )

--- a/mvt/android/cmd_check_bugreport.py
+++ b/mvt/android/cmd_check_bugreport.py
@@ -25,7 +25,7 @@ class CmdAndroidCheckBugreport(Command):
         ioc_files: Optional[list] = None,
         module_name: Optional[str] = None,
         serial: Optional[str] = None,
-        fast_mode: bool = False,
+        module_options: Optional[dict] = None,
         hashes: bool = False,
     ) -> None:
         super().__init__(
@@ -34,7 +34,7 @@ class CmdAndroidCheckBugreport(Command):
             ioc_files=ioc_files,
             module_name=module_name,
             serial=serial,
-            fast_mode=fast_mode,
+            module_options=module_options,
             hashes=hashes,
             log=log,
         )

--- a/mvt/android/modules/adb/base.py
+++ b/mvt/android/modules/adb/base.py
@@ -44,7 +44,7 @@ class AndroidExtraction(MVTModule):
         file_path: Optional[str] = None,
         target_path: Optional[str] = None,
         results_path: Optional[str] = None,
-        fast_mode: bool = False,
+        module_options: Optional[dict] = None,
         log: logging.Logger = logging.getLogger(__name__),
         results: Optional[list] = None,
     ) -> None:
@@ -52,7 +52,7 @@ class AndroidExtraction(MVTModule):
             file_path=file_path,
             target_path=target_path,
             results_path=results_path,
-            fast_mode=fast_mode,
+            module_options=module_options,
             log=log,
             results=results,
         )

--- a/mvt/android/modules/adb/chrome_history.py
+++ b/mvt/android/modules/adb/chrome_history.py
@@ -23,7 +23,7 @@ class ChromeHistory(AndroidExtraction):
         file_path: Optional[str] = None,
         target_path: Optional[str] = None,
         results_path: Optional[str] = None,
-        fast_mode: bool = False,
+        module_options: Optional[dict] = None,
         log: logging.Logger = logging.getLogger(__name__),
         results: Optional[list] = None,
     ) -> None:
@@ -31,7 +31,7 @@ class ChromeHistory(AndroidExtraction):
             file_path=file_path,
             target_path=target_path,
             results_path=results_path,
-            fast_mode=fast_mode,
+            module_options=module_options,
             log=log,
             results=results,
         )

--- a/mvt/android/modules/adb/dumpsys_accessibility.py
+++ b/mvt/android/modules/adb/dumpsys_accessibility.py
@@ -19,7 +19,7 @@ class DumpsysAccessibility(AndroidExtraction):
         file_path: Optional[str] = None,
         target_path: Optional[str] = None,
         results_path: Optional[str] = None,
-        fast_mode: bool = False,
+        module_options: Optional[dict] = None,
         log: logging.Logger = logging.getLogger(__name__),
         results: Optional[list] = None,
     ) -> None:
@@ -27,7 +27,7 @@ class DumpsysAccessibility(AndroidExtraction):
             file_path=file_path,
             target_path=target_path,
             results_path=results_path,
-            fast_mode=fast_mode,
+            module_options=module_options,
             log=log,
             results=results,
         )

--- a/mvt/android/modules/adb/dumpsys_activities.py
+++ b/mvt/android/modules/adb/dumpsys_activities.py
@@ -19,7 +19,7 @@ class DumpsysActivities(AndroidExtraction):
         file_path: Optional[str] = None,
         target_path: Optional[str] = None,
         results_path: Optional[str] = None,
-        fast_mode: bool = False,
+        module_options: Optional[dict] = None,
         log: logging.Logger = logging.getLogger(__name__),
         results: Optional[list] = None,
     ) -> None:
@@ -27,7 +27,7 @@ class DumpsysActivities(AndroidExtraction):
             file_path=file_path,
             target_path=target_path,
             results_path=results_path,
-            fast_mode=fast_mode,
+            module_options=module_options,
             log=log,
             results=results,
         )

--- a/mvt/android/modules/adb/dumpsys_appops.py
+++ b/mvt/android/modules/adb/dumpsys_appops.py
@@ -21,7 +21,7 @@ class DumpsysAppOps(AndroidExtraction):
         file_path: Optional[str] = None,
         target_path: Optional[str] = None,
         results_path: Optional[str] = None,
-        fast_mode: bool = False,
+        module_options: Optional[dict] = None,
         log: logging.Logger = logging.getLogger(__name__),
         results: Optional[list] = None,
     ) -> None:
@@ -29,7 +29,7 @@ class DumpsysAppOps(AndroidExtraction):
             file_path=file_path,
             target_path=target_path,
             results_path=results_path,
-            fast_mode=fast_mode,
+            module_options=module_options,
             log=log,
             results=results,
         )

--- a/mvt/android/modules/adb/dumpsys_battery_daily.py
+++ b/mvt/android/modules/adb/dumpsys_battery_daily.py
@@ -19,7 +19,7 @@ class DumpsysBatteryDaily(AndroidExtraction):
         file_path: Optional[str] = None,
         target_path: Optional[str] = None,
         results_path: Optional[str] = None,
-        fast_mode: bool = False,
+        module_options: Optional[dict] = None,
         log: logging.Logger = logging.getLogger(__name__),
         results: Optional[list] = None,
     ) -> None:
@@ -27,7 +27,7 @@ class DumpsysBatteryDaily(AndroidExtraction):
             file_path=file_path,
             target_path=target_path,
             results_path=results_path,
-            fast_mode=fast_mode,
+            module_options=module_options,
             log=log,
             results=results,
         )

--- a/mvt/android/modules/adb/dumpsys_battery_history.py
+++ b/mvt/android/modules/adb/dumpsys_battery_history.py
@@ -19,7 +19,7 @@ class DumpsysBatteryHistory(AndroidExtraction):
         file_path: Optional[str] = None,
         target_path: Optional[str] = None,
         results_path: Optional[str] = None,
-        fast_mode: bool = False,
+        module_options: Optional[dict] = None,
         log: logging.Logger = logging.getLogger(__name__),
         results: Optional[list] = None,
     ) -> None:
@@ -27,7 +27,7 @@ class DumpsysBatteryHistory(AndroidExtraction):
             file_path=file_path,
             target_path=target_path,
             results_path=results_path,
-            fast_mode=fast_mode,
+            module_options=module_options,
             log=log,
             results=results,
         )

--- a/mvt/android/modules/adb/dumpsys_dbinfo.py
+++ b/mvt/android/modules/adb/dumpsys_dbinfo.py
@@ -21,7 +21,7 @@ class DumpsysDBInfo(AndroidExtraction):
         file_path: Optional[str] = None,
         target_path: Optional[str] = None,
         results_path: Optional[str] = None,
-        fast_mode: bool = False,
+        module_options: Optional[dict] = None,
         log: logging.Logger = logging.getLogger(__name__),
         results: Optional[list] = None,
     ) -> None:
@@ -29,7 +29,7 @@ class DumpsysDBInfo(AndroidExtraction):
             file_path=file_path,
             target_path=target_path,
             results_path=results_path,
-            fast_mode=fast_mode,
+            module_options=module_options,
             log=log,
             results=results,
         )

--- a/mvt/android/modules/adb/dumpsys_full.py
+++ b/mvt/android/modules/adb/dumpsys_full.py
@@ -18,7 +18,7 @@ class DumpsysFull(AndroidExtraction):
         file_path: Optional[str] = None,
         target_path: Optional[str] = None,
         results_path: Optional[str] = None,
-        fast_mode: bool = False,
+        module_options: Optional[dict] = None,
         log: logging.Logger = logging.getLogger(__name__),
         results: Optional[list] = None,
     ) -> None:
@@ -26,7 +26,7 @@ class DumpsysFull(AndroidExtraction):
             file_path=file_path,
             target_path=target_path,
             results_path=results_path,
-            fast_mode=fast_mode,
+            module_options=module_options,
             log=log,
             results=results,
         )

--- a/mvt/android/modules/adb/dumpsys_receivers.py
+++ b/mvt/android/modules/adb/dumpsys_receivers.py
@@ -25,7 +25,7 @@ class DumpsysReceivers(AndroidExtraction):
         file_path: Optional[str] = None,
         target_path: Optional[str] = None,
         results_path: Optional[str] = None,
-        fast_mode: bool = False,
+        module_options: Optional[dict] = None,
         log: logging.Logger = logging.getLogger(__name__),
         results: Optional[list] = None,
     ) -> None:
@@ -33,7 +33,7 @@ class DumpsysReceivers(AndroidExtraction):
             file_path=file_path,
             target_path=target_path,
             results_path=results_path,
-            fast_mode=fast_mode,
+            module_options=module_options,
             log=log,
             results=results,
         )

--- a/mvt/android/modules/adb/files.py
+++ b/mvt/android/modules/adb/files.py
@@ -30,7 +30,7 @@ class Files(AndroidExtraction):
         file_path: Optional[str] = None,
         target_path: Optional[str] = None,
         results_path: Optional[str] = None,
-        fast_mode: bool = False,
+        module_options: Optional[dict] = None,
         log: logging.Logger = logging.getLogger(__name__),
         results: Optional[list] = None,
     ) -> None:
@@ -38,7 +38,7 @@ class Files(AndroidExtraction):
             file_path=file_path,
             target_path=target_path,
             results_path=results_path,
-            fast_mode=fast_mode,
+            module_options=module_options,
             log=log,
             results=results,
         )
@@ -142,8 +142,10 @@ class Files(AndroidExtraction):
             "Found %s files in primary Android tmp and media folders", len(self.results)
         )
 
-        if self.fast_mode:
-            self.log.info("Flag --fast was enabled: skipping full file listing")
+        if self.module_options.get("fast_mode", None):
+            self.log.info(
+                "The `fast_mode` option was enabled: skipping full file listing"
+            )
         else:
             self.log.info("Processing full file listing. This may take a while...")
             self.find_files("/")

--- a/mvt/android/modules/adb/getprop.py
+++ b/mvt/android/modules/adb/getprop.py
@@ -20,7 +20,7 @@ class Getprop(AndroidExtraction):
         file_path: Optional[str] = None,
         target_path: Optional[str] = None,
         results_path: Optional[str] = None,
-        fast_mode: bool = False,
+        module_options: Optional[dict] = None,
         log: logging.Logger = logging.getLogger(__name__),
         results: Optional[list] = None,
     ) -> None:
@@ -28,7 +28,7 @@ class Getprop(AndroidExtraction):
             file_path=file_path,
             target_path=target_path,
             results_path=results_path,
-            fast_mode=fast_mode,
+            module_options=module_options,
             log=log,
             results=results,
         )

--- a/mvt/android/modules/adb/logcat.py
+++ b/mvt/android/modules/adb/logcat.py
@@ -18,7 +18,7 @@ class Logcat(AndroidExtraction):
         file_path: Optional[str] = None,
         target_path: Optional[str] = None,
         results_path: Optional[str] = None,
-        fast_mode: bool = False,
+        module_options: Optional[dict] = None,
         log: logging.Logger = logging.getLogger(__name__),
         results: Optional[list] = None,
     ) -> None:
@@ -26,7 +26,7 @@ class Logcat(AndroidExtraction):
             file_path=file_path,
             target_path=target_path,
             results_path=results_path,
-            fast_mode=fast_mode,
+            module_options=module_options,
             log=log,
             results=results,
         )

--- a/mvt/android/modules/adb/packages.py
+++ b/mvt/android/modules/adb/packages.py
@@ -93,7 +93,7 @@ class Packages(AndroidExtraction):
         file_path: Optional[str] = None,
         target_path: Optional[str] = None,
         results_path: Optional[str] = None,
-        fast_mode: bool = False,
+        module_options: Optional[dict] = None,
         log: logging.Logger = logging.getLogger(__name__),
         results: Optional[list] = None,
     ) -> None:
@@ -101,7 +101,7 @@ class Packages(AndroidExtraction):
             file_path=file_path,
             target_path=target_path,
             results_path=results_path,
-            fast_mode=fast_mode,
+            module_options=module_options,
             log=log,
             results=results,
         )
@@ -351,7 +351,7 @@ class Packages(AndroidExtraction):
                 result["timestamp"],
             )
 
-        if not self.fast_mode:
+        if not self.module_options.get("fast_mode", None):
             self.check_virustotal(packages_to_lookup)
 
         self.log.info(

--- a/mvt/android/modules/adb/processes.py
+++ b/mvt/android/modules/adb/processes.py
@@ -17,7 +17,7 @@ class Processes(AndroidExtraction):
         file_path: Optional[str] = None,
         target_path: Optional[str] = None,
         results_path: Optional[str] = None,
-        fast_mode: bool = False,
+        module_options: Optional[dict] = None,
         log: logging.Logger = logging.getLogger(__name__),
         results: Optional[list] = None,
     ) -> None:
@@ -25,7 +25,7 @@ class Processes(AndroidExtraction):
             file_path=file_path,
             target_path=target_path,
             results_path=results_path,
-            fast_mode=fast_mode,
+            module_options=module_options,
             log=log,
             results=results,
         )

--- a/mvt/android/modules/adb/root_binaries.py
+++ b/mvt/android/modules/adb/root_binaries.py
@@ -17,7 +17,7 @@ class RootBinaries(AndroidExtraction):
         file_path: Optional[str] = None,
         target_path: Optional[str] = None,
         results_path: Optional[str] = None,
-        fast_mode: bool = False,
+        module_options: Optional[dict] = None,
         log: logging.Logger = logging.getLogger(__name__),
         results: Optional[list] = None,
     ) -> None:
@@ -25,7 +25,7 @@ class RootBinaries(AndroidExtraction):
             file_path=file_path,
             target_path=target_path,
             results_path=results_path,
-            fast_mode=fast_mode,
+            module_options=module_options,
             log=log,
             results=results,
         )

--- a/mvt/android/modules/adb/selinux_status.py
+++ b/mvt/android/modules/adb/selinux_status.py
@@ -19,7 +19,7 @@ class SELinuxStatus(AndroidExtraction):
         file_path: Optional[str] = None,
         target_path: Optional[str] = None,
         results_path: Optional[str] = None,
-        fast_mode: bool = False,
+        module_options: Optional[dict] = None,
         log: logging.Logger = logging.getLogger(__name__),
         results: Optional[list] = None,
     ) -> None:
@@ -27,7 +27,7 @@ class SELinuxStatus(AndroidExtraction):
             file_path=file_path,
             target_path=target_path,
             results_path=results_path,
-            fast_mode=fast_mode,
+            module_options=module_options,
             log=log,
             results=results,
         )

--- a/mvt/android/modules/adb/settings.py
+++ b/mvt/android/modules/adb/settings.py
@@ -65,7 +65,7 @@ class Settings(AndroidExtraction):
         file_path: Optional[str] = None,
         target_path: Optional[str] = None,
         results_path: Optional[str] = None,
-        fast_mode: bool = False,
+        module_options: Optional[dict] = None,
         log: logging.Logger = logging.getLogger(__name__),
         results: Optional[list] = None,
     ) -> None:
@@ -73,7 +73,7 @@ class Settings(AndroidExtraction):
             file_path=file_path,
             target_path=target_path,
             results_path=results_path,
-            fast_mode=fast_mode,
+            module_options=module_options,
             log=log,
             results=results,
         )

--- a/mvt/android/modules/adb/sms.py
+++ b/mvt/android/modules/adb/sms.py
@@ -49,7 +49,7 @@ class SMS(AndroidExtraction):
         file_path: Optional[str] = None,
         target_path: Optional[str] = None,
         results_path: Optional[str] = None,
-        fast_mode: bool = False,
+        module_options: Optional[dict] = None,
         log: logging.Logger = logging.getLogger(__name__),
         results: Optional[list] = None,
     ) -> None:
@@ -57,7 +57,7 @@ class SMS(AndroidExtraction):
             file_path=file_path,
             target_path=target_path,
             results_path=results_path,
-            fast_mode=fast_mode,
+            module_options=module_options,
             log=log,
             results=results,
         )

--- a/mvt/android/modules/adb/whatsapp.py
+++ b/mvt/android/modules/adb/whatsapp.py
@@ -24,7 +24,7 @@ class Whatsapp(AndroidExtraction):
         file_path: Optional[str] = None,
         target_path: Optional[str] = None,
         results_path: Optional[str] = None,
-        fast_mode: bool = False,
+        module_options: Optional[dict] = None,
         log: logging.Logger = logging.getLogger(__name__),
         results: Optional[list] = None,
     ) -> None:
@@ -32,7 +32,7 @@ class Whatsapp(AndroidExtraction):
             file_path=file_path,
             target_path=target_path,
             results_path=results_path,
-            fast_mode=fast_mode,
+            module_options=module_options,
             log=log,
             results=results,
         )

--- a/mvt/android/modules/androidqf/base.py
+++ b/mvt/android/modules/androidqf/base.py
@@ -19,7 +19,7 @@ class AndroidQFModule(MVTModule):
         file_path: Optional[str] = None,
         target_path: Optional[str] = None,
         results_path: Optional[str] = None,
-        fast_mode: bool = False,
+        module_options: Optional[dict] = None,
         log: logging.Logger = logging.getLogger(__name__),
         results: Union[List[Dict[str, Any]], Dict[str, Any], None] = None,
     ) -> None:
@@ -27,7 +27,7 @@ class AndroidQFModule(MVTModule):
             file_path=file_path,
             target_path=target_path,
             results_path=results_path,
-            fast_mode=fast_mode,
+            module_options=module_options,
             log=log,
             results=results,
         )

--- a/mvt/android/modules/androidqf/dumpsys_accessibility.py
+++ b/mvt/android/modules/androidqf/dumpsys_accessibility.py
@@ -19,7 +19,7 @@ class DumpsysAccessibility(AndroidQFModule):
         file_path: Optional[str] = None,
         target_path: Optional[str] = None,
         results_path: Optional[str] = None,
-        fast_mode: bool = False,
+        module_options: Optional[dict] = None,
         log: logging.Logger = logging.getLogger(__name__),
         results: Optional[list] = None,
     ) -> None:
@@ -27,7 +27,7 @@ class DumpsysAccessibility(AndroidQFModule):
             file_path=file_path,
             target_path=target_path,
             results_path=results_path,
-            fast_mode=fast_mode,
+            module_options=module_options,
             log=log,
             results=results,
         )

--- a/mvt/android/modules/androidqf/dumpsys_activities.py
+++ b/mvt/android/modules/androidqf/dumpsys_activities.py
@@ -19,7 +19,7 @@ class DumpsysActivities(AndroidQFModule):
         file_path: Optional[str] = None,
         target_path: Optional[str] = None,
         results_path: Optional[str] = None,
-        fast_mode: bool = False,
+        module_options: Optional[dict] = None,
         log: logging.Logger = logging.getLogger(__name__),
         results: Optional[list] = None,
     ) -> None:
@@ -27,7 +27,7 @@ class DumpsysActivities(AndroidQFModule):
             file_path=file_path,
             target_path=target_path,
             results_path=results_path,
-            fast_mode=fast_mode,
+            module_options=module_options,
             log=log,
             results=results,
         )

--- a/mvt/android/modules/androidqf/dumpsys_appops.py
+++ b/mvt/android/modules/androidqf/dumpsys_appops.py
@@ -17,7 +17,7 @@ class DumpsysAppops(AndroidQFModule):
         file_path: Optional[str] = None,
         target_path: Optional[str] = None,
         results_path: Optional[str] = None,
-        fast_mode: bool = False,
+        module_options: Optional[dict] = None,
         log: logging.Logger = logging.getLogger(__name__),
         results: Optional[list] = None,
     ) -> None:
@@ -25,7 +25,7 @@ class DumpsysAppops(AndroidQFModule):
             file_path=file_path,
             target_path=target_path,
             results_path=results_path,
-            fast_mode=fast_mode,
+            module_options=module_options,
             log=log,
             results=results,
         )

--- a/mvt/android/modules/androidqf/dumpsys_packages.py
+++ b/mvt/android/modules/androidqf/dumpsys_packages.py
@@ -24,7 +24,7 @@ class DumpsysPackages(AndroidQFModule):
         file_path: Optional[str] = None,
         target_path: Optional[str] = None,
         results_path: Optional[str] = None,
-        fast_mode: bool = False,
+        module_options: Optional[dict] = None,
         log: logging.Logger = logging.getLogger(__name__),
         results: Optional[List[Dict[str, Any]]] = None,
     ) -> None:
@@ -32,7 +32,7 @@ class DumpsysPackages(AndroidQFModule):
             file_path=file_path,
             target_path=target_path,
             results_path=results_path,
-            fast_mode=fast_mode,
+            module_options=module_options,
             log=log,
             results=results,
         )

--- a/mvt/android/modules/androidqf/dumpsys_receivers.py
+++ b/mvt/android/modules/androidqf/dumpsys_receivers.py
@@ -26,7 +26,7 @@ class DumpsysReceivers(AndroidQFModule):
         file_path: Optional[str] = None,
         target_path: Optional[str] = None,
         results_path: Optional[str] = None,
-        fast_mode: bool = False,
+        module_options: Optional[dict] = None,
         log: logging.Logger = logging.getLogger(__name__),
         results: Union[List[Any], Dict[str, Any], None] = None,
     ) -> None:
@@ -34,7 +34,7 @@ class DumpsysReceivers(AndroidQFModule):
             file_path=file_path,
             target_path=target_path,
             results_path=results_path,
-            fast_mode=fast_mode,
+            module_options=module_options,
             log=log,
             results=results,
         )

--- a/mvt/android/modules/androidqf/getprop.py
+++ b/mvt/android/modules/androidqf/getprop.py
@@ -34,7 +34,7 @@ class Getprop(AndroidQFModule):
         file_path: Optional[str] = None,
         target_path: Optional[str] = None,
         results_path: Optional[str] = None,
-        fast_mode: bool = False,
+        module_options: Optional[dict] = None,
         log: logging.Logger = logging.getLogger(__name__),
         results: Optional[list] = None,
     ) -> None:
@@ -42,7 +42,7 @@ class Getprop(AndroidQFModule):
             file_path=file_path,
             target_path=target_path,
             results_path=results_path,
-            fast_mode=fast_mode,
+            module_options=module_options,
             log=log,
             results=results,
         )

--- a/mvt/android/modules/androidqf/processes.py
+++ b/mvt/android/modules/androidqf/processes.py
@@ -17,7 +17,7 @@ class Processes(AndroidQFModule):
         file_path: Optional[str] = None,
         target_path: Optional[str] = None,
         results_path: Optional[str] = None,
-        fast_mode: bool = False,
+        module_options: Optional[dict] = None,
         log: logging.Logger = logging.getLogger(__name__),
         results: Optional[list] = None,
     ) -> None:
@@ -25,7 +25,7 @@ class Processes(AndroidQFModule):
             file_path=file_path,
             target_path=target_path,
             results_path=results_path,
-            fast_mode=fast_mode,
+            module_options=module_options,
             log=log,
             results=results,
         )

--- a/mvt/android/modules/androidqf/settings.py
+++ b/mvt/android/modules/androidqf/settings.py
@@ -19,7 +19,7 @@ class Settings(AndroidQFModule):
         file_path: Optional[str] = None,
         target_path: Optional[str] = None,
         results_path: Optional[str] = None,
-        fast_mode: bool = False,
+        module_options: Optional[dict] = None,
         log: logging.Logger = logging.getLogger(__name__),
         results: Optional[list] = None,
     ) -> None:
@@ -27,7 +27,7 @@ class Settings(AndroidQFModule):
             file_path=file_path,
             target_path=target_path,
             results_path=results_path,
-            fast_mode=fast_mode,
+            module_options=module_options,
             log=log,
             results=results,
         )

--- a/mvt/android/modules/androidqf/sms.py
+++ b/mvt/android/modules/androidqf/sms.py
@@ -26,7 +26,7 @@ class SMS(AndroidQFModule):
         file_path: Optional[str] = None,
         target_path: Optional[str] = None,
         results_path: Optional[str] = None,
-        fast_mode: bool = False,
+        module_options: Optional[dict] = None,
         log: logging.Logger = logging.getLogger(__name__),
         results: Optional[list] = None,
     ) -> None:
@@ -34,7 +34,7 @@ class SMS(AndroidQFModule):
             file_path=file_path,
             target_path=target_path,
             results_path=results_path,
-            fast_mode=fast_mode,
+            module_options=module_options,
             log=log,
             results=results,
         )

--- a/mvt/android/modules/backup/base.py
+++ b/mvt/android/modules/backup/base.py
@@ -20,7 +20,7 @@ class BackupExtraction(MVTModule):
         file_path: Optional[str] = None,
         target_path: Optional[str] = None,
         results_path: Optional[str] = None,
-        fast_mode: bool = False,
+        module_options: Optional[dict] = None,
         log: logging.Logger = logging.getLogger(__name__),
         results: Optional[list] = None,
     ) -> None:
@@ -28,7 +28,7 @@ class BackupExtraction(MVTModule):
             file_path=file_path,
             target_path=target_path,
             results_path=results_path,
-            fast_mode=fast_mode,
+            module_options=module_options,
             log=log,
             results=results,
         )

--- a/mvt/android/modules/backup/sms.py
+++ b/mvt/android/modules/backup/sms.py
@@ -17,7 +17,7 @@ class SMS(BackupExtraction):
         file_path: Optional[str] = None,
         target_path: Optional[str] = None,
         results_path: Optional[str] = None,
-        fast_mode: bool = False,
+        module_options: Optional[dict] = None,
         log: logging.Logger = logging.getLogger(__name__),
         results: Optional[list] = None,
     ) -> None:
@@ -25,7 +25,7 @@ class SMS(BackupExtraction):
             file_path=file_path,
             target_path=target_path,
             results_path=results_path,
-            fast_mode=fast_mode,
+            module_options=module_options,
             log=log,
             results=results,
         )

--- a/mvt/android/modules/bugreport/accessibility.py
+++ b/mvt/android/modules/bugreport/accessibility.py
@@ -19,7 +19,7 @@ class Accessibility(BugReportModule):
         file_path: Optional[str] = None,
         target_path: Optional[str] = None,
         results_path: Optional[str] = None,
-        fast_mode: bool = False,
+        module_options: Optional[dict] = None,
         log: logging.Logger = logging.getLogger(__name__),
         results: Optional[list] = None,
     ) -> None:
@@ -27,7 +27,7 @@ class Accessibility(BugReportModule):
             file_path=file_path,
             target_path=target_path,
             results_path=results_path,
-            fast_mode=fast_mode,
+            module_options=module_options,
             log=log,
             results=results,
         )

--- a/mvt/android/modules/bugreport/activities.py
+++ b/mvt/android/modules/bugreport/activities.py
@@ -19,7 +19,7 @@ class Activities(BugReportModule):
         file_path: Optional[str] = None,
         target_path: Optional[str] = None,
         results_path: Optional[str] = None,
-        fast_mode: bool = False,
+        module_options: Optional[dict] = None,
         log: logging.Logger = logging.getLogger(__name__),
         results: Optional[list] = None,
     ) -> None:
@@ -27,7 +27,7 @@ class Activities(BugReportModule):
             file_path=file_path,
             target_path=target_path,
             results_path=results_path,
-            fast_mode=fast_mode,
+            module_options=module_options,
             log=log,
             results=results,
         )

--- a/mvt/android/modules/bugreport/appops.py
+++ b/mvt/android/modules/bugreport/appops.py
@@ -19,7 +19,7 @@ class Appops(BugReportModule):
         file_path: Optional[str] = None,
         target_path: Optional[str] = None,
         results_path: Optional[str] = None,
-        fast_mode: bool = False,
+        module_options: Optional[dict] = None,
         log: logging.Logger = logging.getLogger(__name__),
         results: Optional[list] = None,
     ) -> None:
@@ -27,7 +27,7 @@ class Appops(BugReportModule):
             file_path=file_path,
             target_path=target_path,
             results_path=results_path,
-            fast_mode=fast_mode,
+            module_options=module_options,
             log=log,
             results=results,
         )

--- a/mvt/android/modules/bugreport/base.py
+++ b/mvt/android/modules/bugreport/base.py
@@ -20,7 +20,7 @@ class BugReportModule(MVTModule):
         file_path: Optional[str] = None,
         target_path: Optional[str] = None,
         results_path: Optional[str] = None,
-        fast_mode: bool = False,
+        module_options: Optional[dict] = None,
         log: logging.Logger = logging.getLogger(__name__),
         results: Optional[list] = None,
     ) -> None:
@@ -28,7 +28,7 @@ class BugReportModule(MVTModule):
             file_path=file_path,
             target_path=target_path,
             results_path=results_path,
-            fast_mode=fast_mode,
+            module_options=module_options,
             log=log,
             results=results,
         )

--- a/mvt/android/modules/bugreport/battery_daily.py
+++ b/mvt/android/modules/bugreport/battery_daily.py
@@ -19,7 +19,7 @@ class BatteryDaily(BugReportModule):
         file_path: Optional[str] = None,
         target_path: Optional[str] = None,
         results_path: Optional[str] = None,
-        fast_mode: bool = False,
+        module_options: Optional[dict] = None,
         log: logging.Logger = logging.getLogger(__name__),
         results: Optional[list] = None,
     ) -> None:
@@ -27,7 +27,7 @@ class BatteryDaily(BugReportModule):
             file_path=file_path,
             target_path=target_path,
             results_path=results_path,
-            fast_mode=fast_mode,
+            module_options=module_options,
             log=log,
             results=results,
         )

--- a/mvt/android/modules/bugreport/battery_history.py
+++ b/mvt/android/modules/bugreport/battery_history.py
@@ -19,7 +19,7 @@ class BatteryHistory(BugReportModule):
         file_path: Optional[str] = None,
         target_path: Optional[str] = None,
         results_path: Optional[str] = None,
-        fast_mode: bool = False,
+        module_options: Optional[dict] = None,
         log: logging.Logger = logging.getLogger(__name__),
         results: Optional[list] = None,
     ) -> None:
@@ -27,7 +27,7 @@ class BatteryHistory(BugReportModule):
             file_path=file_path,
             target_path=target_path,
             results_path=results_path,
-            fast_mode=fast_mode,
+            module_options=module_options,
             log=log,
             results=results,
         )

--- a/mvt/android/modules/bugreport/dbinfo.py
+++ b/mvt/android/modules/bugreport/dbinfo.py
@@ -21,7 +21,7 @@ class DBInfo(BugReportModule):
         file_path: Optional[str] = None,
         target_path: Optional[str] = None,
         results_path: Optional[str] = None,
-        fast_mode: bool = False,
+        module_options: Optional[dict] = None,
         log: logging.Logger = logging.getLogger(__name__),
         results: Optional[list] = None,
     ) -> None:
@@ -29,7 +29,7 @@ class DBInfo(BugReportModule):
             file_path=file_path,
             target_path=target_path,
             results_path=results_path,
-            fast_mode=fast_mode,
+            module_options=module_options,
             log=log,
             results=results,
         )

--- a/mvt/android/modules/bugreport/getprop.py
+++ b/mvt/android/modules/bugreport/getprop.py
@@ -20,7 +20,7 @@ class Getprop(BugReportModule):
         file_path: Optional[str] = None,
         target_path: Optional[str] = None,
         results_path: Optional[str] = None,
-        fast_mode: bool = False,
+        module_options: Optional[dict] = None,
         log: logging.Logger = logging.getLogger(__name__),
         results: Optional[list] = None,
     ) -> None:
@@ -28,7 +28,7 @@ class Getprop(BugReportModule):
             file_path=file_path,
             target_path=target_path,
             results_path=results_path,
-            fast_mode=fast_mode,
+            module_options=module_options,
             log=log,
             results=results,
         )

--- a/mvt/android/modules/bugreport/packages.py
+++ b/mvt/android/modules/bugreport/packages.py
@@ -24,7 +24,7 @@ class Packages(BugReportModule):
         file_path: Optional[str] = None,
         target_path: Optional[str] = None,
         results_path: Optional[str] = None,
-        fast_mode: bool = False,
+        module_options: Optional[dict] = None,
         log: logging.Logger = logging.getLogger(__name__),
         results: Optional[list] = None,
     ) -> None:
@@ -32,7 +32,7 @@ class Packages(BugReportModule):
             file_path=file_path,
             target_path=target_path,
             results_path=results_path,
-            fast_mode=fast_mode,
+            module_options=module_options,
             log=log,
             results=results,
         )

--- a/mvt/android/modules/bugreport/receivers.py
+++ b/mvt/android/modules/bugreport/receivers.py
@@ -25,7 +25,7 @@ class Receivers(BugReportModule):
         file_path: Optional[str] = None,
         target_path: Optional[str] = None,
         results_path: Optional[str] = None,
-        fast_mode: bool = False,
+        module_options: Optional[dict] = None,
         log: logging.Logger = logging.getLogger(__name__),
         results: Optional[list] = None,
     ) -> None:
@@ -33,7 +33,7 @@ class Receivers(BugReportModule):
             file_path=file_path,
             target_path=target_path,
             results_path=results_path,
-            fast_mode=fast_mode,
+            module_options=module_options,
             log=log,
             results=results,
         )

--- a/mvt/common/cmd_check_iocs.py
+++ b/mvt/common/cmd_check_iocs.py
@@ -21,7 +21,7 @@ class CmdCheckIOCS(Command):
         ioc_files: Optional[list] = None,
         module_name: Optional[str] = None,
         serial: Optional[str] = None,
-        fast_mode: bool = False,
+        module_options: Optional[dict] = None,
     ) -> None:
         super().__init__(
             target_path=target_path,
@@ -29,7 +29,7 @@ class CmdCheckIOCS(Command):
             ioc_files=ioc_files,
             module_name=module_name,
             serial=serial,
-            fast_mode=fast_mode,
+            module_options=module_options,
             log=log,
         )
 

--- a/mvt/common/command.py
+++ b/mvt/common/command.py
@@ -28,7 +28,7 @@ class Command:
         ioc_files: Optional[list] = None,
         module_name: Optional[str] = None,
         serial: Optional[str] = None,
-        fast_mode: bool = False,
+        module_options: Optional[dict] = None,
         hashes: bool = False,
         log: logging.Logger = logging.getLogger(__name__),
     ) -> None:
@@ -40,8 +40,12 @@ class Command:
         self.ioc_files = ioc_files if ioc_files else []
         self.module_name = module_name
         self.serial = serial
-        self.fast_mode = fast_mode
         self.log = log
+
+        # This dictionary can contain options that will be passed down from
+        # the Command to all modules. This can for example be used to pass
+        # down a password to decrypt a backup or flags which are need by some modules.
+        self.module_options = module_options if module_options else {}
 
         # This list will contain all executed modules.
         # We can use this to reference e.g. self.executed[0].results.
@@ -172,7 +176,7 @@ class Command:
             m = module(
                 target_path=self.target_path,
                 results_path=self.results_path,
-                fast_mode=self.fast_mode,
+                module_options=self.module_options,
                 log=module_logger,
             )
 

--- a/mvt/common/module.py
+++ b/mvt/common/module.py
@@ -37,7 +37,7 @@ class MVTModule:
         file_path: Optional[str] = None,
         target_path: Optional[str] = None,
         results_path: Optional[str] = None,
-        fast_mode: bool = False,
+        module_options: Optional[Dict[str, Any]] = None,
         log: logging.Logger = logging.getLogger(__name__),
         results: Union[List[Dict[str, Any]], Dict[str, Any], None] = None,
     ) -> None:
@@ -59,7 +59,7 @@ class MVTModule:
         self.file_path = file_path
         self.target_path = target_path
         self.results_path = results_path
-        self.fast_mode = fast_mode
+        self.module_options = module_options if module_options else {}
         self.log = log
         self.indicators = None
         self.results = results if results else []

--- a/mvt/ios/cli.py
+++ b/mvt/ios/cli.py
@@ -219,13 +219,14 @@ def check_backup(
     ctx, iocs, output, fast, list_modules, module, hashes, verbose, backup_path
 ):
     set_verbose_logging(verbose)
+    module_options = {"fast_mode": fast}
 
     cmd = CmdIOSCheckBackup(
         target_path=backup_path,
         results_path=output,
         ioc_files=iocs,
         module_name=module,
-        fast_mode=fast,
+        module_options=module_options,
         hashes=hashes,
     )
 
@@ -269,12 +270,14 @@ def check_backup(
 @click.pass_context
 def check_fs(ctx, iocs, output, fast, list_modules, module, hashes, verbose, dump_path):
     set_verbose_logging(verbose)
+    module_options = {"fast_mode": fast}
+
     cmd = CmdIOSCheckFS(
         target_path=dump_path,
         results_path=output,
         ioc_files=iocs,
         module_name=module,
-        fast_mode=fast,
+        module_options=module_options,
         hashes=hashes,
     )
 

--- a/mvt/ios/cmd_check_backup.py
+++ b/mvt/ios/cmd_check_backup.py
@@ -22,7 +22,7 @@ class CmdIOSCheckBackup(Command):
         ioc_files: Optional[list] = None,
         module_name: Optional[str] = None,
         serial: Optional[str] = None,
-        fast_mode: bool = False,
+        module_options: Optional[dict] = None,
         hashes: bool = False,
     ) -> None:
         super().__init__(
@@ -31,7 +31,7 @@ class CmdIOSCheckBackup(Command):
             ioc_files=ioc_files,
             module_name=module_name,
             serial=serial,
-            fast_mode=fast_mode,
+            module_options=module_options,
             hashes=hashes,
             log=log,
         )

--- a/mvt/ios/cmd_check_fs.py
+++ b/mvt/ios/cmd_check_fs.py
@@ -22,7 +22,7 @@ class CmdIOSCheckFS(Command):
         ioc_files: Optional[list] = None,
         module_name: Optional[str] = None,
         serial: Optional[str] = None,
-        fast_mode: bool = False,
+        module_options: Optional[dict] = None,
         hashes: bool = False,
     ) -> None:
         super().__init__(
@@ -31,7 +31,7 @@ class CmdIOSCheckFS(Command):
             ioc_files=ioc_files,
             module_name=module_name,
             serial=serial,
-            fast_mode=fast_mode,
+            module_options=module_options,
             hashes=hashes,
             log=log,
         )

--- a/mvt/ios/modules/backup/backup_info.py
+++ b/mvt/ios/modules/backup/backup_info.py
@@ -22,7 +22,7 @@ class BackupInfo(IOSExtraction):
         file_path: Optional[str] = None,
         target_path: Optional[str] = None,
         results_path: Optional[str] = None,
-        fast_mode: bool = False,
+        module_options: Optional[dict] = None,
         log: logging.Logger = logging.getLogger(__name__),
         results: Optional[list] = None,
     ) -> None:
@@ -30,7 +30,7 @@ class BackupInfo(IOSExtraction):
             file_path=file_path,
             target_path=target_path,
             results_path=results_path,
-            fast_mode=fast_mode,
+            module_options=module_options,
             log=log,
             results=results,
         )

--- a/mvt/ios/modules/backup/configuration_profiles.py
+++ b/mvt/ios/modules/backup/configuration_profiles.py
@@ -26,7 +26,7 @@ class ConfigurationProfiles(IOSExtraction):
         file_path: Optional[str] = None,
         target_path: Optional[str] = None,
         results_path: Optional[str] = None,
-        fast_mode: bool = False,
+        module_options: Optional[dict] = None,
         log: logging.Logger = logging.getLogger(__name__),
         results: Optional[list] = None,
     ) -> None:
@@ -34,7 +34,7 @@ class ConfigurationProfiles(IOSExtraction):
             file_path=file_path,
             target_path=target_path,
             results_path=results_path,
-            fast_mode=fast_mode,
+            module_options=module_options,
             log=log,
             results=results,
         )

--- a/mvt/ios/modules/backup/manifest.py
+++ b/mvt/ios/modules/backup/manifest.py
@@ -26,7 +26,7 @@ class Manifest(IOSExtraction):
         file_path: Optional[str] = None,
         target_path: Optional[str] = None,
         results_path: Optional[str] = None,
-        fast_mode: bool = False,
+        module_options: Optional[dict] = None,
         log: logging.Logger = logging.getLogger(__name__),
         results: Optional[list] = None,
     ) -> None:
@@ -34,7 +34,7 @@ class Manifest(IOSExtraction):
             file_path=file_path,
             target_path=target_path,
             results_path=results_path,
-            fast_mode=fast_mode,
+            module_options=module_options,
             log=log,
             results=results,
         )

--- a/mvt/ios/modules/backup/profile_events.py
+++ b/mvt/ios/modules/backup/profile_events.py
@@ -27,7 +27,7 @@ class ProfileEvents(IOSExtraction):
         file_path: Optional[str] = None,
         target_path: Optional[str] = None,
         results_path: Optional[str] = None,
-        fast_mode: bool = False,
+        module_options: Optional[dict] = None,
         log: logging.Logger = logging.getLogger(__name__),
         results: Optional[list] = None,
     ) -> None:
@@ -35,7 +35,7 @@ class ProfileEvents(IOSExtraction):
             file_path=file_path,
             target_path=target_path,
             results_path=results_path,
-            fast_mode=fast_mode,
+            module_options=module_options,
             log=log,
             results=results,
         )

--- a/mvt/ios/modules/base.py
+++ b/mvt/ios/modules/base.py
@@ -23,7 +23,7 @@ class IOSExtraction(MVTModule):
         file_path: Optional[str] = None,
         target_path: Optional[str] = None,
         results_path: Optional[str] = None,
-        fast_mode: bool = False,
+        module_options: Optional[dict] = None,
         log: logging.Logger = logging.getLogger(__name__),
         results: Optional[list] = None,
     ) -> None:
@@ -31,7 +31,7 @@ class IOSExtraction(MVTModule):
             file_path=file_path,
             target_path=target_path,
             results_path=results_path,
-            fast_mode=fast_mode,
+            module_options=module_options,
             log=log,
             results=results,
         )

--- a/mvt/ios/modules/fs/analytics.py
+++ b/mvt/ios/modules/fs/analytics.py
@@ -27,7 +27,7 @@ class Analytics(IOSExtraction):
         file_path: Optional[str] = None,
         target_path: Optional[str] = None,
         results_path: Optional[str] = None,
-        fast_mode: bool = False,
+        module_options: Optional[dict] = None,
         log: logging.Logger = logging.getLogger(__name__),
         results: Optional[list] = None,
     ) -> None:
@@ -35,7 +35,7 @@ class Analytics(IOSExtraction):
             file_path=file_path,
             target_path=target_path,
             results_path=results_path,
-            fast_mode=fast_mode,
+            module_options=module_options,
             log=log,
             results=results,
         )

--- a/mvt/ios/modules/fs/analytics_ios_versions.py
+++ b/mvt/ios/modules/fs/analytics_ios_versions.py
@@ -23,7 +23,7 @@ class AnalyticsIOSVersions(IOSExtraction):
         file_path: Optional[str] = None,
         target_path: Optional[str] = None,
         results_path: Optional[str] = None,
-        fast_mode: bool = False,
+        module_options: Optional[dict] = None,
         log: logging.Logger = logging.getLogger(__name__),
         results: Optional[list] = None,
     ) -> None:
@@ -31,7 +31,7 @@ class AnalyticsIOSVersions(IOSExtraction):
             file_path=file_path,
             target_path=target_path,
             results_path=results_path,
-            fast_mode=fast_mode,
+            module_options=module_options,
             log=log,
             results=results,
         )

--- a/mvt/ios/modules/fs/cache_files.py
+++ b/mvt/ios/modules/fs/cache_files.py
@@ -17,7 +17,7 @@ class CacheFiles(IOSExtraction):
         file_path: Optional[str] = None,
         target_path: Optional[str] = None,
         results_path: Optional[str] = None,
-        fast_mode: bool = False,
+        module_options: Optional[dict] = None,
         log: logging.Logger = logging.getLogger(__name__),
         results: Optional[list] = None,
     ) -> None:
@@ -25,7 +25,7 @@ class CacheFiles(IOSExtraction):
             file_path=file_path,
             target_path=target_path,
             results_path=results_path,
-            fast_mode=fast_mode,
+            module_options=module_options,
             log=log,
             results=results,
         )

--- a/mvt/ios/modules/fs/filesystem.py
+++ b/mvt/ios/modules/fs/filesystem.py
@@ -22,7 +22,7 @@ class Filesystem(IOSExtraction):
         file_path: Optional[str] = None,
         target_path: Optional[str] = None,
         results_path: Optional[str] = None,
-        fast_mode: bool = False,
+        module_options: Optional[dict] = None,
         log: logging.Logger = logging.getLogger(__name__),
         results: Optional[list] = None,
     ) -> None:
@@ -30,7 +30,7 @@ class Filesystem(IOSExtraction):
             file_path=file_path,
             target_path=target_path,
             results_path=results_path,
-            fast_mode=fast_mode,
+            module_options=module_options,
             log=log,
             results=results,
         )
@@ -57,7 +57,7 @@ class Filesystem(IOSExtraction):
                 self.detected.append(result)
 
             # If we are instructed to run fast, we skip the rest.
-            if self.fast_mode:
+            if self.module_options.get("fast_mode", None):
                 continue
 
             ioc = self.indicators.check_file_path_process(result["path"])

--- a/mvt/ios/modules/fs/net_netusage.py
+++ b/mvt/ios/modules/fs/net_netusage.py
@@ -27,7 +27,7 @@ class Netusage(NetBase):
         file_path: Optional[str] = None,
         target_path: Optional[str] = None,
         results_path: Optional[str] = None,
-        fast_mode: bool = False,
+        module_options: Optional[dict] = None,
         log: logging.Logger = logging.getLogger(__name__),
         results: Optional[list] = None,
     ) -> None:
@@ -35,7 +35,7 @@ class Netusage(NetBase):
             file_path=file_path,
             target_path=target_path,
             results_path=results_path,
-            fast_mode=fast_mode,
+            module_options=module_options,
             log=log,
             results=results,
         )

--- a/mvt/ios/modules/fs/safari_favicon.py
+++ b/mvt/ios/modules/fs/safari_favicon.py
@@ -25,7 +25,7 @@ class SafariFavicon(IOSExtraction):
         file_path: Optional[str] = None,
         target_path: Optional[str] = None,
         results_path: Optional[str] = None,
-        fast_mode: bool = False,
+        module_options: Optional[dict] = None,
         log: logging.Logger = logging.getLogger(__name__),
         results: Optional[list] = None,
     ) -> None:
@@ -33,7 +33,7 @@ class SafariFavicon(IOSExtraction):
             file_path=file_path,
             target_path=target_path,
             results_path=results_path,
-            fast_mode=fast_mode,
+            module_options=module_options,
             log=log,
             results=results,
         )

--- a/mvt/ios/modules/fs/shutdownlog.py
+++ b/mvt/ios/modules/fs/shutdownlog.py
@@ -23,7 +23,7 @@ class ShutdownLog(IOSExtraction):
         file_path: Optional[str] = None,
         target_path: Optional[str] = None,
         results_path: Optional[str] = None,
-        fast_mode: bool = False,
+        module_options: Optional[dict] = None,
         log: logging.Logger = logging.getLogger(__name__),
         results: Optional[list] = None,
     ) -> None:
@@ -31,7 +31,7 @@ class ShutdownLog(IOSExtraction):
             file_path=file_path,
             target_path=target_path,
             results_path=results_path,
-            fast_mode=fast_mode,
+            module_options=module_options,
             log=log,
             results=results,
         )

--- a/mvt/ios/modules/fs/version_history.py
+++ b/mvt/ios/modules/fs/version_history.py
@@ -25,7 +25,7 @@ class IOSVersionHistory(IOSExtraction):
         file_path: Optional[str] = None,
         target_path: Optional[str] = None,
         results_path: Optional[str] = None,
-        fast_mode: bool = False,
+        module_options: Optional[dict] = None,
         log: logging.Logger = logging.getLogger(__name__),
         results: Optional[list] = None,
     ) -> None:
@@ -33,7 +33,7 @@ class IOSVersionHistory(IOSExtraction):
             file_path=file_path,
             target_path=target_path,
             results_path=results_path,
-            fast_mode=fast_mode,
+            module_options=module_options,
             log=log,
             results=results,
         )

--- a/mvt/ios/modules/fs/webkit_indexeddb.py
+++ b/mvt/ios/modules/fs/webkit_indexeddb.py
@@ -27,7 +27,7 @@ class WebkitIndexedDB(WebkitBase):
         file_path: Optional[str] = None,
         target_path: Optional[str] = None,
         results_path: Optional[str] = None,
-        fast_mode: bool = False,
+        module_options: Optional[dict] = None,
         log: logging.Logger = logging.getLogger(__name__),
         results: Optional[list] = None,
     ) -> None:
@@ -35,7 +35,7 @@ class WebkitIndexedDB(WebkitBase):
             file_path=file_path,
             target_path=target_path,
             results_path=results_path,
-            fast_mode=fast_mode,
+            module_options=module_options,
             log=log,
             results=results,
         )

--- a/mvt/ios/modules/fs/webkit_localstorage.py
+++ b/mvt/ios/modules/fs/webkit_localstorage.py
@@ -25,7 +25,7 @@ class WebkitLocalStorage(WebkitBase):
         file_path: Optional[str] = None,
         target_path: Optional[str] = None,
         results_path: Optional[str] = None,
-        fast_mode: bool = False,
+        module_options: Optional[dict] = None,
         log: logging.Logger = logging.getLogger(__name__),
         results: Optional[list] = None,
     ) -> None:
@@ -33,7 +33,7 @@ class WebkitLocalStorage(WebkitBase):
             file_path=file_path,
             target_path=target_path,
             results_path=results_path,
-            fast_mode=fast_mode,
+            module_options=module_options,
             log=log,
             results=results,
         )

--- a/mvt/ios/modules/fs/webkit_safariviewservice.py
+++ b/mvt/ios/modules/fs/webkit_safariviewservice.py
@@ -25,7 +25,7 @@ class WebkitSafariViewService(WebkitBase):
         file_path: Optional[str] = None,
         target_path: Optional[str] = None,
         results_path: Optional[str] = None,
-        fast_mode: bool = False,
+        module_options: Optional[dict] = None,
         log: logging.Logger = logging.getLogger(__name__),
         results: Optional[list] = None,
     ) -> None:
@@ -33,7 +33,7 @@ class WebkitSafariViewService(WebkitBase):
             file_path=file_path,
             target_path=target_path,
             results_path=results_path,
-            fast_mode=fast_mode,
+            module_options=module_options,
             log=log,
             results=results,
         )

--- a/mvt/ios/modules/mixed/applications.py
+++ b/mvt/ios/modules/mixed/applications.py
@@ -27,7 +27,7 @@ class Applications(IOSExtraction):
         file_path: Optional[str] = None,
         target_path: Optional[str] = None,
         results_path: Optional[str] = None,
-        fast_mode: bool = False,
+        module_options: Optional[dict] = None,
         log: logging.Logger = logging.getLogger(__name__),
         results: Optional[list] = None,
     ) -> None:
@@ -35,7 +35,7 @@ class Applications(IOSExtraction):
             file_path=file_path,
             target_path=target_path,
             results_path=results_path,
-            fast_mode=fast_mode,
+            module_options=module_options,
             log=log,
             results=results,
         )

--- a/mvt/ios/modules/mixed/calendar.py
+++ b/mvt/ios/modules/mixed/calendar.py
@@ -25,7 +25,7 @@ class Calendar(IOSExtraction):
         file_path: Optional[str] = None,
         target_path: Optional[str] = None,
         results_path: Optional[str] = None,
-        fast_mode: bool = False,
+        module_options: Optional[dict] = None,
         log: logging.Logger = logging.getLogger(__name__),
         results: Optional[list] = None,
     ) -> None:
@@ -33,7 +33,7 @@ class Calendar(IOSExtraction):
             file_path=file_path,
             target_path=target_path,
             results_path=results_path,
-            fast_mode=fast_mode,
+            module_options=module_options,
             log=log,
             results=results,
         )

--- a/mvt/ios/modules/mixed/calls.py
+++ b/mvt/ios/modules/mixed/calls.py
@@ -5,7 +5,7 @@
 
 import logging
 import sqlite3
-from typing import Union
+from typing import Union, Optional
 
 from mvt.common.utils import convert_mactime_to_iso
 
@@ -25,7 +25,7 @@ class Calls(IOSExtraction):
         file_path: str = None,
         target_path: str = None,
         results_path: str = None,
-        fast_mode: bool = False,
+        module_options: Optional[dict] = None,
         log: logging.Logger = logging.getLogger(__name__),
         results: list = [],
     ) -> None:
@@ -33,7 +33,7 @@ class Calls(IOSExtraction):
             file_path=file_path,
             target_path=target_path,
             results_path=results_path,
-            fast_mode=fast_mode,
+            module_options=module_options,
             log=log,
             results=results,
         )

--- a/mvt/ios/modules/mixed/chrome_favicon.py
+++ b/mvt/ios/modules/mixed/chrome_favicon.py
@@ -26,7 +26,7 @@ class ChromeFavicon(IOSExtraction):
         file_path: Optional[str] = None,
         target_path: Optional[str] = None,
         results_path: Optional[str] = None,
-        fast_mode: bool = False,
+        module_options: Optional[dict] = None,
         log: logging.Logger = logging.getLogger(__name__),
         results: Optional[list] = None,
     ) -> None:
@@ -34,7 +34,7 @@ class ChromeFavicon(IOSExtraction):
             file_path=file_path,
             target_path=target_path,
             results_path=results_path,
-            fast_mode=fast_mode,
+            module_options=module_options,
             log=log,
             results=results,
         )

--- a/mvt/ios/modules/mixed/chrome_history.py
+++ b/mvt/ios/modules/mixed/chrome_history.py
@@ -28,7 +28,7 @@ class ChromeHistory(IOSExtraction):
         file_path: Optional[str] = None,
         target_path: Optional[str] = None,
         results_path: Optional[str] = None,
-        fast_mode: bool = False,
+        module_options: Optional[dict] = None,
         log: logging.Logger = logging.getLogger(__name__),
         results: Optional[list] = None,
     ) -> None:
@@ -36,7 +36,7 @@ class ChromeHistory(IOSExtraction):
             file_path=file_path,
             target_path=target_path,
             results_path=results_path,
-            fast_mode=fast_mode,
+            module_options=module_options,
             log=log,
             results=results,
         )

--- a/mvt/ios/modules/mixed/contacts.py
+++ b/mvt/ios/modules/mixed/contacts.py
@@ -25,7 +25,7 @@ class Contacts(IOSExtraction):
         file_path: Optional[str] = None,
         target_path: Optional[str] = None,
         results_path: Optional[str] = None,
-        fast_mode: bool = False,
+        module_options: Optional[dict] = None,
         log: logging.Logger = logging.getLogger(__name__),
         results: Optional[list] = None,
     ) -> None:
@@ -33,7 +33,7 @@ class Contacts(IOSExtraction):
             file_path=file_path,
             target_path=target_path,
             results_path=results_path,
-            fast_mode=fast_mode,
+            module_options=module_options,
             log=log,
             results=results,
         )

--- a/mvt/ios/modules/mixed/firefox_favicon.py
+++ b/mvt/ios/modules/mixed/firefox_favicon.py
@@ -27,7 +27,7 @@ class FirefoxFavicon(IOSExtraction):
         file_path: Optional[str] = None,
         target_path: Optional[str] = None,
         results_path: Optional[str] = None,
-        fast_mode: bool = False,
+        module_options: Optional[dict] = None,
         log: logging.Logger = logging.getLogger(__name__),
         results: Optional[list] = None,
     ) -> None:
@@ -35,7 +35,7 @@ class FirefoxFavicon(IOSExtraction):
             file_path=file_path,
             target_path=target_path,
             results_path=results_path,
-            fast_mode=fast_mode,
+            module_options=module_options,
             log=log,
             results=results,
         )

--- a/mvt/ios/modules/mixed/firefox_history.py
+++ b/mvt/ios/modules/mixed/firefox_history.py
@@ -31,7 +31,7 @@ class FirefoxHistory(IOSExtraction):
         file_path: Optional[str] = None,
         target_path: Optional[str] = None,
         results_path: Optional[str] = None,
-        fast_mode: bool = False,
+        module_options: Optional[dict] = None,
         log: logging.Logger = logging.getLogger(__name__),
         results: Optional[list] = None,
     ) -> None:
@@ -39,7 +39,7 @@ class FirefoxHistory(IOSExtraction):
             file_path=file_path,
             target_path=target_path,
             results_path=results_path,
-            fast_mode=fast_mode,
+            module_options=module_options,
             log=log,
             results=results,
         )

--- a/mvt/ios/modules/mixed/idstatuscache.py
+++ b/mvt/ios/modules/mixed/idstatuscache.py
@@ -29,7 +29,7 @@ class IDStatusCache(IOSExtraction):
         file_path: Optional[str] = None,
         target_path: Optional[str] = None,
         results_path: Optional[str] = None,
-        fast_mode: bool = False,
+        module_options: Optional[dict] = None,
         log: logging.Logger = logging.getLogger(__name__),
         results: Optional[list] = None,
     ) -> None:
@@ -37,7 +37,7 @@ class IDStatusCache(IOSExtraction):
             file_path=file_path,
             target_path=target_path,
             results_path=results_path,
-            fast_mode=fast_mode,
+            module_options=module_options,
             log=log,
             results=results,
         )

--- a/mvt/ios/modules/mixed/interactionc.py
+++ b/mvt/ios/modules/mixed/interactionc.py
@@ -221,7 +221,7 @@ class InteractionC(IOSExtraction):
         file_path: Optional[str] = None,
         target_path: Optional[str] = None,
         results_path: Optional[str] = None,
-        fast_mode: bool = False,
+        module_options: Optional[dict] = None,
         log: logging.Logger = logging.getLogger(__name__),
         results: Optional[list] = None,
     ) -> None:
@@ -229,7 +229,7 @@ class InteractionC(IOSExtraction):
             file_path=file_path,
             target_path=target_path,
             results_path=results_path,
-            fast_mode=fast_mode,
+            module_options=module_options,
             log=log,
             results=results,
         )

--- a/mvt/ios/modules/mixed/locationd.py
+++ b/mvt/ios/modules/mixed/locationd.py
@@ -28,7 +28,7 @@ class LocationdClients(IOSExtraction):
         file_path: Optional[str] = None,
         target_path: Optional[str] = None,
         results_path: Optional[str] = None,
-        fast_mode: bool = False,
+        module_options: Optional[dict] = None,
         log: logging.Logger = logging.getLogger(__name__),
         results: Optional[list] = None,
     ) -> None:
@@ -36,7 +36,7 @@ class LocationdClients(IOSExtraction):
             file_path=file_path,
             target_path=target_path,
             results_path=results_path,
-            fast_mode=fast_mode,
+            module_options=module_options,
             log=log,
             results=results,
         )

--- a/mvt/ios/modules/mixed/net_datausage.py
+++ b/mvt/ios/modules/mixed/net_datausage.py
@@ -28,7 +28,7 @@ class Datausage(NetBase):
         file_path: Optional[str] = None,
         target_path: Optional[str] = None,
         results_path: Optional[str] = None,
-        fast_mode: bool = False,
+        module_options: Optional[dict] = None,
         log: logging.Logger = logging.getLogger(__name__),
         results: Optional[list] = None,
     ) -> None:
@@ -36,7 +36,7 @@ class Datausage(NetBase):
             file_path=file_path,
             target_path=target_path,
             results_path=results_path,
-            fast_mode=fast_mode,
+            module_options=module_options,
             log=log,
             results=results,
         )

--- a/mvt/ios/modules/mixed/osanalytics_addaily.py
+++ b/mvt/ios/modules/mixed/osanalytics_addaily.py
@@ -28,7 +28,7 @@ class OSAnalyticsADDaily(IOSExtraction):
         file_path: Optional[str] = None,
         target_path: Optional[str] = None,
         results_path: Optional[str] = None,
-        fast_mode: bool = False,
+        module_options: Optional[dict] = None,
         log: logging.Logger = logging.getLogger(__name__),
         results: Optional[list] = None,
     ) -> None:
@@ -36,7 +36,7 @@ class OSAnalyticsADDaily(IOSExtraction):
             file_path=file_path,
             target_path=target_path,
             results_path=results_path,
-            fast_mode=fast_mode,
+            module_options=module_options,
             log=log,
             results=results,
         )

--- a/mvt/ios/modules/mixed/safari_browserstate.py
+++ b/mvt/ios/modules/mixed/safari_browserstate.py
@@ -29,7 +29,7 @@ class SafariBrowserState(IOSExtraction):
         file_path: Optional[str] = None,
         target_path: Optional[str] = None,
         results_path: Optional[str] = None,
-        fast_mode: bool = False,
+        module_options: Optional[dict] = None,
         log: logging.Logger = logging.getLogger(__name__),
         results: Optional[list] = None,
     ) -> None:
@@ -37,7 +37,7 @@ class SafariBrowserState(IOSExtraction):
             file_path=file_path,
             target_path=target_path,
             results_path=results_path,
-            fast_mode=fast_mode,
+            module_options=module_options,
             log=log,
             results=results,
         )

--- a/mvt/ios/modules/mixed/safari_history.py
+++ b/mvt/ios/modules/mixed/safari_history.py
@@ -32,7 +32,7 @@ class SafariHistory(IOSExtraction):
         file_path: Optional[str] = None,
         target_path: Optional[str] = None,
         results_path: Optional[str] = None,
-        fast_mode: bool = False,
+        module_options: Optional[dict] = None,
         log: logging.Logger = logging.getLogger(__name__),
         results: Optional[list] = None,
     ) -> None:
@@ -40,7 +40,7 @@ class SafariHistory(IOSExtraction):
             file_path=file_path,
             target_path=target_path,
             results_path=results_path,
-            fast_mode=fast_mode,
+            module_options=module_options,
             log=log,
             results=results,
         )

--- a/mvt/ios/modules/mixed/shortcuts.py
+++ b/mvt/ios/modules/mixed/shortcuts.py
@@ -30,7 +30,7 @@ class Shortcuts(IOSExtraction):
         file_path: Optional[str] = None,
         target_path: Optional[str] = None,
         results_path: Optional[str] = None,
-        fast_mode: bool = False,
+        module_options: Optional[dict] = None,
         log: logging.Logger = logging.getLogger(__name__),
         results: Optional[list] = None,
     ) -> None:
@@ -38,7 +38,7 @@ class Shortcuts(IOSExtraction):
             file_path=file_path,
             target_path=target_path,
             results_path=results_path,
-            fast_mode=fast_mode,
+            module_options=module_options,
             log=log,
             results=results,
         )

--- a/mvt/ios/modules/mixed/sms.py
+++ b/mvt/ios/modules/mixed/sms.py
@@ -28,7 +28,7 @@ class SMS(IOSExtraction):
         file_path: Optional[str] = None,
         target_path: Optional[str] = None,
         results_path: Optional[str] = None,
-        fast_mode: bool = False,
+        module_options: Optional[dict] = None,
         log: logging.Logger = logging.getLogger(__name__),
         results: Optional[list] = None,
     ) -> None:
@@ -36,7 +36,7 @@ class SMS(IOSExtraction):
             file_path=file_path,
             target_path=target_path,
             results_path=results_path,
-            fast_mode=fast_mode,
+            module_options=module_options,
             log=log,
             results=results,
         )

--- a/mvt/ios/modules/mixed/sms_attachments.py
+++ b/mvt/ios/modules/mixed/sms_attachments.py
@@ -28,7 +28,7 @@ class SMSAttachments(IOSExtraction):
         file_path: Optional[str] = None,
         target_path: Optional[str] = None,
         results_path: Optional[str] = None,
-        fast_mode: bool = False,
+        module_options: Optional[dict] = None,
         log: logging.Logger = logging.getLogger(__name__),
         results: Optional[list] = None,
     ) -> None:
@@ -36,7 +36,7 @@ class SMSAttachments(IOSExtraction):
             file_path=file_path,
             target_path=target_path,
             results_path=results_path,
-            fast_mode=fast_mode,
+            module_options=module_options,
             log=log,
             results=results,
         )

--- a/mvt/ios/modules/mixed/tcc.py
+++ b/mvt/ios/modules/mixed/tcc.py
@@ -49,7 +49,7 @@ class TCC(IOSExtraction):
         file_path: Optional[str] = None,
         target_path: Optional[str] = None,
         results_path: Optional[str] = None,
-        fast_mode: bool = False,
+        module_options: Optional[dict] = None,
         log: logging.Logger = logging.getLogger(__name__),
         results: Optional[list] = None,
     ) -> None:
@@ -57,7 +57,7 @@ class TCC(IOSExtraction):
             file_path=file_path,
             target_path=target_path,
             results_path=results_path,
-            fast_mode=fast_mode,
+            module_options=module_options,
             log=log,
             results=results,
         )

--- a/mvt/ios/modules/mixed/webkit_resource_load_statistics.py
+++ b/mvt/ios/modules/mixed/webkit_resource_load_statistics.py
@@ -28,7 +28,7 @@ class WebkitResourceLoadStatistics(IOSExtraction):
         file_path: Optional[str] = None,
         target_path: Optional[str] = None,
         results_path: Optional[str] = None,
-        fast_mode: bool = False,
+        module_options: Optional[dict] = None,
         log: logging.Logger = logging.getLogger(__name__),
         results: Optional[list] = None,
     ) -> None:
@@ -36,7 +36,7 @@ class WebkitResourceLoadStatistics(IOSExtraction):
             file_path=file_path,
             target_path=target_path,
             results_path=results_path,
-            fast_mode=fast_mode,
+            module_options=module_options,
             log=log,
             results=results,
         )

--- a/mvt/ios/modules/mixed/webkit_session_resource_log.py
+++ b/mvt/ios/modules/mixed/webkit_session_resource_log.py
@@ -36,7 +36,7 @@ class WebkitSessionResourceLog(IOSExtraction):
         file_path: Optional[str] = None,
         target_path: Optional[str] = None,
         results_path: Optional[str] = None,
-        fast_mode: bool = False,
+        module_options: Optional[dict] = None,
         log: logging.Logger = logging.getLogger(__name__),
         results: Optional[list] = None,
     ) -> None:
@@ -44,7 +44,7 @@ class WebkitSessionResourceLog(IOSExtraction):
             file_path=file_path,
             target_path=target_path,
             results_path=results_path,
-            fast_mode=fast_mode,
+            module_options=module_options,
             log=log,
             results=results,
         )

--- a/mvt/ios/modules/mixed/whatsapp.py
+++ b/mvt/ios/modules/mixed/whatsapp.py
@@ -27,7 +27,7 @@ class Whatsapp(IOSExtraction):
         file_path: Optional[str] = None,
         target_path: Optional[str] = None,
         results_path: Optional[str] = None,
-        fast_mode: bool = False,
+        module_options: Optional[dict] = None,
         log: logging.Logger = logging.getLogger(__name__),
         results: Optional[list] = None,
     ) -> None:
@@ -35,7 +35,7 @@ class Whatsapp(IOSExtraction):
             file_path=file_path,
             target_path=target_path,
             results_path=results_path,
-            fast_mode=fast_mode,
+            module_options=module_options,
             log=log,
             results=results,
         )

--- a/mvt/ios/modules/net_base.py
+++ b/mvt/ios/modules/net_base.py
@@ -23,7 +23,7 @@ class NetBase(IOSExtraction):
         file_path: Optional[str] = None,
         target_path: Optional[str] = None,
         results_path: Optional[str] = None,
-        fast_mode: bool = False,
+        module_options: Optional[dict] = None,
         log: logging.Logger = logging.getLogger(__name__),
         results: Optional[list] = None,
     ) -> None:
@@ -31,7 +31,7 @@ class NetBase(IOSExtraction):
             file_path=file_path,
             target_path=target_path,
             results_path=results_path,
-            fast_mode=fast_mode,
+            module_options=module_options,
             log=log,
             results=results,
         )
@@ -157,9 +157,9 @@ class NetBase(IOSExtraction):
             return
 
         # If we are instructed to run fast, we skip this.
-        if self.fast_mode:
+        if self.module_options.get("fast_mode", None):
             self.log.info(
-                "Flag --fast was enabled: skipping extended "
+                "Option 'fast_mode' was enabled: skipping extended "
                 "search for suspicious processes"
             )
             return


### PR DESCRIPTION
We currently don't have a clean may to pass configuration options or values such as passwords (as seen in issue #363) from the CLI commands all the way down to individual MVT modules. 

The approach so far has been to add a parameter such as `fast_mode` to the MVT module base signature. This works, but is very painful to maintain as it requires a code change to every MVT module and any applications using that code when a parameter is added or changed.

This PR instead adds a `module_options` parameter which can take a dictionary with optional keys and values which are then passed down and available in each MVT module during execution. This is a breaking change which will require updates to any dependent libraries which use MVT modules directly.

This PR also removes the `fast_mode` parameter and instead passes that through `module_options`. As an enhancement we should consider using an object for `module_options` to track the possible keys which can be used.