### PR TITLE
Move detection and alerts from run() to check_indicators()

### DIFF
--- a/mvt/android/modules/adb/root_binaries.py
+++ b/mvt/android/modules/adb/root_binaries.py
@@ -30,6 +30,11 @@ class RootBinaries(AndroidExtraction):
             results=results,
         )
 
+    def check_indicators(self) -> None:
+        for root_binary in self.results:
+            self.detected.append(root_binary)
+            self.log.warning('Found root binary "%s"', root_binary)
+
     def run(self) -> None:
         root_binaries = [
             "su",
@@ -60,7 +65,6 @@ class RootBinaries(AndroidExtraction):
             if "which: not found" in output:
                 continue
 
-            self.detected.append(root_binary)
-            self.log.warning('Found root binary "%s"', root_binary)
+            self.results.append(root_binary)
 
         self._adb_disconnect()

--- a/mvt/ios/modules/backup/manifest.py
+++ b/mvt/ios/modules/backup/manifest.py
@@ -91,19 +91,6 @@ class Manifest(IOSExtraction):
             if not result.get("relative_path"):
                 continue
 
-            if result["domain"]:
-                if (
-                    os.path.basename(result["relative_path"])
-                    == "com.apple.CrashReporter.plist"
-                    and result["domain"] == "RootDomain"
-                ):
-                    self.log.warning(
-                        "Found a potentially suspicious "
-                        '"com.apple.CrashReporter.plist" file created in RootDomain'
-                    )
-                    self.detected.append(result)
-                    continue
-
             if not self.indicators:
                 continue
 

--- a/mvt/ios/modules/mixed/sms.py
+++ b/mvt/ios/modules/mixed/sms.py
@@ -66,7 +66,7 @@ class SMS(IOSExtraction):
                 self.log.warning(
                     "Apple warning about state-sponsored attack received on the %s",
                     message["isodate"],
-                    )
+                )
 
         if not self.indicators:
             return

--- a/mvt/ios/modules/mixed/sms.py
+++ b/mvt/ios/modules/mixed/sms.py
@@ -60,6 +60,14 @@ class SMS(IOSExtraction):
         ]
 
     def check_indicators(self) -> None:
+        for message in self.results:
+            alert = "ALERT: State-sponsored attackers may be targeting your iPhone"
+            if message.get("text", "").startswith(alert):
+                self.log.warning(
+                    "Apple warning about state-sponsored attack received on the %s",
+                    message["isodate"],
+                    )
+
         if not self.indicators:
             return
 
@@ -137,17 +145,9 @@ class SMS(IOSExtraction):
             if not message.get("text", None):
                 message["text"] = ""
 
-            alert = "ALERT: State-sponsored attackers may be targeting your iPhone"
-            if message.get("text", "").startswith(alert):
-                self.log.warning(
-                    "Apple warning about state-sponsored attack received on the %s",
-                    message["isodate"],
-                )
-            else:
-                # Extract links from the SMS message.
-                message_links = check_for_links(message.get("text", ""))
-                message["links"] = message_links
-
+            # Extract links from the SMS message.
+            message_links = check_for_links(message.get("text", ""))
+            message["links"] = message_links
             self.results.append(message)
 
         cur.close()


### PR DESCRIPTION
All detection logic and indicator checking should be in `check_indicators` so that we can re-run new detection logic against previous acquisitions and MVT log files. The `run` stage should just focus on data extraction and parsing.