### PR TITLE
Make `MVTModule.get_slug()` a classmethod

### DIFF
--- a/mvt/common/cmd_check_iocs.py
+++ b/mvt/common/cmd_check_iocs.py
@@ -53,7 +53,7 @@ class CmdCheckIOCS(Command):
                 if self.module_name and iocs_module.__name__ != self.module_name:
                     continue
 
-                if iocs_module().get_slug() != name_only:
+                if iocs_module.get_slug() != name_only:
                     continue
 
                 log.info(

--- a/mvt/common/module.py
+++ b/mvt/common/module.py
@@ -74,12 +74,13 @@ class MVTModule:
                 log.info('Loaded %d results from "%s"', len(results), json_path)
             return cls(results=results, log=log)
 
-    def get_slug(self) -> str:
+    @classmethod
+    def get_slug(cls) -> str:
         """Use the module's class name to retrieve a slug"""
-        if self.slug:
-            return self.slug
+        if cls.slug:
+            return cls.slug
 
-        sub = re.sub("(.)([A-Z][a-z]+)", r"\1_\2", self.__class__.__name__)
+        sub = re.sub("(.)([A-Z][a-z]+)", r"\1_\2", cls.__name__)
         return re.sub("([a-z0-9])([A-Z])", r"\1_\2", sub).lower()
 
     def check_indicators(self) -> None:


### PR DESCRIPTION
Sometimes it can be useful to be able to iterate the module classes and get the "slug"/name before the module is actually initialized. Since modules define their custom `slug` as a class variable, `get_slug()` can be called without an instance of the class.

https://github.com/mvt-project/mvt/blob/73104814ba10127b8c3fd64b4f23cc3dbcc0ccb0/mvt/ios/modules/fs/webkit_indexeddb.py#L16-L25
