### PR TITLE
Allow PR coverage comment to fail if running on a fork

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -42,6 +42,7 @@ jobs:
     - name: Test with pytest and coverage
       run: pytest --junitxml=pytest.xml --cov-report=term-missing:skip-covered --cov=mvt tests/ | tee pytest-coverage.txt
     - name: Pytest coverage comment
+      continue-on-error: true # Workflows running on a fork can't post comments
       uses: MishaKav/pytest-coverage-comment@main
       if: github.event_name == 'pull_request'
       with:


### PR DESCRIPTION
CI was failing on all external contributions as the default permissions for a workflow running on a forked repo are limited. This allows the job to succeed even if the coverage comment doesn't work.