### PR TITLE
Impovements for SMS module

### DIFF
--- a/mvt/ios/modules/mixed/sms.py
+++ b/mvt/ios/modules/mixed/sms.py
@@ -44,20 +44,25 @@ class SMS(IOSExtraction):
     def serialize(self, record: dict) -> Union[dict, list]:
         text = record["text"].replace("\n", "\\n")
         sms_data = f"{record['service']}: {record['guid']} \"{text}\" from {record['phone_number']} ({record['account']})"
-        return [
+        sms_data = [
             {
                 "timestamp": record["isodate"],
                 "module": self.__class__.__name__,
                 "event": "sms_received",
                 "data": sms_data,
             },
-            {
-                "timestamp": record["isodate_read"],
-                "module": self.__class__.__name__,
-                "event": "sms_read",
-                "data": sms_data,
-            },
         ]
+        # If the message was read, we add an extra event.
+        if record["isodate_read"]:
+            sms_data.append(
+                {
+                    "timestamp": record["isodate_read"],
+                    "module": self.__class__.__name__,
+                    "event": "sms_read",
+                    "data": sms_data,
+                }
+            )
+        return sms_data
 
     def check_indicators(self) -> None:
         for message in self.results:

--- a/mvt/ios/modules/mixed/sms_attachments.py
+++ b/mvt/ios/modules/mixed/sms_attachments.py
@@ -57,7 +57,6 @@ class SMSAttachments(IOSExtraction):
         for attachment in self.results:
             # Check for known malicious filenames.
             if self.indicators.check_file_path(attachment["filename"]):
-                print("Found malicious filename", attachment["filename"])
                 self.detected.append(attachment)
 
             if (

--- a/mvt/ios/modules/mixed/sms_attachments.py
+++ b/mvt/ios/modules/mixed/sms_attachments.py
@@ -55,6 +55,11 @@ class SMSAttachments(IOSExtraction):
 
     def check_indicators(self) -> None:
         for attachment in self.results:
+            # Check for known malicious filenames.
+            if self.indicators.check_file_path(attachment["filename"]):
+                print("Found malicious filename", attachment["filename"])
+                self.detected.append(attachment)
+
             if (
                 attachment["filename"].startswith("/var/tmp/")
                 and attachment["filename"].endswith("-1")

--- a/tests/ios_backup/test_sms.py
+++ b/tests/ios_backup/test_sms.py
@@ -17,7 +17,7 @@ class TestSMSModule:
         m = SMS(target_path=get_ios_backup_folder())
         run_module(m)
         assert len(m.results) == 1
-        assert len(m.timeline) == 2  # SMS received and read events.
+        assert len(m.timeline) == 1
         assert len(m.detected) == 0
 
     def test_detection(self, indicator_file):


### PR DESCRIPTION
The SMS module was creating noisy entries in the timeline as it would output timeline `sms_read` entries for SMS messages even when no `sms_read` timeline was set. This branch fixes the module so that messages which were not read do not produce an extra entry.

This branch also adds basic indicator checking in the SMS module.