### PR TITLE
change virustotal flag to -V

### DIFF
--- a/mvt/android/cli.py
+++ b/mvt/android/cli.py
@@ -72,7 +72,7 @@ def version():
     is_flag=True,
     help="Extract all packages installed on the phone, including system packages",
 )
-@click.option("--virustotal", "-v", is_flag=True, help="Check packages on VirusTotal")
+@click.option("--virustotal", "-V", is_flag=True, help="Check packages on VirusTotal")
 @click.option(
     "--output",
     "-o",


### PR DESCRIPTION
for the `download-apks` command  `-v` is defined as shorthand for both `--virustotal` and --`verbose`.

Suggesting to change `--virustotal`  to use `-V` (upper v) for short.