### PR TITLE
Add `uri=True` in mvt/ios/modules/base.py

### DIFF
--- a/mvt/ios/modules/base.py
+++ b/mvt/ios/modules/base.py
@@ -92,7 +92,7 @@ class IOSExtraction(MVTModule):
         self.log.info("Database at path %s recovered successfully!", file_path)
 
     def _open_sqlite_db(self, file_path: str) -> sqlite3.Connection:
-        return sqlite3.connect(f"file:{file_path}?immutable=1")
+        return sqlite3.connect(f"file:{file_path}?immutable=1", uri=True)
 
     def _get_backup_files_from_manifest(
         self, relative_path: Optional[str] = None, domain: Optional[str] = None


### PR DESCRIPTION
This fixes #434 - tested on Ubuntu 22.04, Python 3.11.6

[`uri` was added in Python 3.4](https://docs.python.org/3/library/sqlite3.html) and it looks like this repo already requires >=3.8

I did not add 3.11 to `.github/workflows/python-package.yml` because it causes the CI to fail on safety (outdated pip - requires >=23.3), but unit tests seem to pass on this version