### PR TITLE
Usbmuxd debug option changed from -d to -v

### DIFF
--- a/docs/ios/install.md
+++ b/docs/ios/install.md
@@ -48,7 +48,7 @@ ideviceinfo
 This should show many details on the connected iOS device. If you are connecting the device to your laptop for the first time, it will require to unlock and enter the PIN code on the mobile device. If it complains that no device is connected and the mobile device is indeed plugged in through the USB cable, you might need to do this first, although typically the pairing is automatically done when connecting the device:
 
 ```bash
-sudo usbmuxd -f -d
+sudo usbmuxd -f -v
 idevicepair pair
 ```
 


### PR DESCRIPTION
Updated docs, to replace -d with -v to start usbmuxd

```
$ usbmuxd -V
usbmuxd 1.1.1

$ usbmuxd -f -d
usbmuxd: invalid option -- 'd'
Usage: usbmuxd [OPTIONS]
```