### PR TITLE
Add preliminary ipv4-addr ioc matching support under collection domains

### DIFF
--- a/mvt/common/indicators.py
+++ b/mvt/common/indicators.py
@@ -13,6 +13,7 @@ import ahocorasick
 from appdirs import user_data_dir
 
 from .url import URL
+import ipaddress
 
 MVT_DATA_FOLDER = user_data_dir("mvt")
 MVT_INDICATORS_FOLDER = os.path.join(MVT_DATA_FOLDER, "indicators")
@@ -97,6 +98,29 @@ class Indicators:
                 ioc_coll=collection,
                 ioc_coll_list=collection["domains"],
             )
+        if key == "ipv4-addr:value":
+            # Check for cidr notation, and add each ip to the domains collection
+            if "/" in value:
+                try:
+                    network = ipaddress.ip_network(value.strip("'"), strict=False)
+                    for ip in network.hosts():
+                        self._add_indicator(
+                            ioc="'" + str(ip) + "'",
+                            ioc_coll=collection,
+                            ioc_coll_list=collection["domains"],
+                        )
+                except ValueError:
+                    self.log.critical(
+                        "Invalid CIDR notation ipv4-addr:value %s in STIX2 indicator file!", value
+                    )
+                    return
+            else:
+                # Single IP address, add to domains collection
+                self._add_indicator(
+                    ioc=value,
+                    ioc_coll=collection,
+                    ioc_coll_list=collection["domains"],
+                )
         elif key == "process:name":
             self._add_indicator(
                 ioc=value, ioc_coll=collection, ioc_coll_list=collection["processes"]

--- a/tests/artifacts/generate_stix.py
+++ b/tests/artifacts/generate_stix.py
@@ -13,6 +13,7 @@ def generate_test_stix_file(file_path):
         os.remove(file_path)
 
     domains = ["example.org"]
+    ip_addresses = ["198.51.100.1"]
     processes = ["Launch"]
     emails = ["foobar@example.org"]
     filenames = ["/var/foobar/txt"]
@@ -25,6 +26,15 @@ def generate_test_stix_file(file_path):
         i = Indicator(
             indicator_types=["malicious-activity"],
             pattern="[domain-name:value='{}']".format(d),
+            pattern_type="stix",
+        )
+        res.append(i)
+        res.append(Relationship(i, "indicates", malware))
+
+    for a in ip_addresses:
+        i = Indicator(
+            indicator_types=["malicious-activity"],
+            pattern="[ipv4-addr:value='{}']".format(d),
             pattern_type="stix",
         )
         res.append(i)


### PR DESCRIPTION
This adds preliminary support to match for any ipv4-addr ioc as if it was a domain.
So any browser activity to http://<ipv4-addr:value> would flag as a known suspicious domain.

Future wise it might make more sense to completely separate ipv4-addr matching logic from the current domain matching logic. But at least for now this would flag as a detection now also for:
https://raw.githubusercontent.com/mvt-project/mvt-indicators/main/2023-07-25_wyrmspy_dragonegg/ip-addresses.txt
