### PR TITLE
Add docs explaining how to seek expert help for forensic analysis 

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ MVT supports using public [indicators of compromise (IOCs)](https://github.com/m
 >
 > Reliable and comprehensive digital forensic support and triage requires access to non-public indicators, research and threat intelligence.
 >
->Such support is available to civil society through [Amnesty International's Security Lab](https://www.amnesty.org/en/tech/) or through our forensic partnership with [Access Now’s Digital Security Helpline](https://www.accessnow.org/help/).
+>Such support is available to civil society through [Amnesty International's Security Lab](https://securitylab.amnesty.org/get-help/?c=mvt_docs) or through our forensic partnership with [Access Now’s Digital Security Helpline](https://www.accessnow.org/help/).
 
 More information about using indicators of compromise with MVT is available in the [documentation](https://docs.mvt.re/en/latest/iocs/).
 

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -21,7 +21,7 @@ MVT supports using [indicators of compromise (IOCs)](https://github.com/mvt-proj
 
     Reliable and comprehensive digital forensic support and triage requires access to non-public indicators, research and threat intelligence.
 
-    Such support is available to civil society through [Amnesty International's Security Lab](https://securitylab.amnesty.org/contact-us/) or [Access Now’s Digital Security Helpline](https://www.accessnow.org/help/).
+    Such support is available to civil society through [Amnesty International's Security Lab](https://securitylab.amnesty.org/get-help/?c=mvt_docs) or [Access Now’s Digital Security Helpline](https://www.accessnow.org/help/).
 
 More information about using indicators of compromise with MVT is available in the [documentation](iocs.md).
 

--- a/mvt/common/command.py
+++ b/mvt/common/command.py
@@ -160,15 +160,25 @@ class Command:
     def finish(self) -> None:
         raise NotImplementedError
 
+    def _show_disable_adb_warning(self) -> None:
+        """Warn if ADB is enabled"""
+        if type(self).__name__ in ["CmdAndroidCheckADB", "CmdAndroidCheckAndroidQF"]:
+            self.log.info(
+                "Please disable ADB (Android Debug Bridge) on the device once finished with the acquisition. "
+                "ADB is a powerful tool which can allow unauthorized access to the device."
+            )
+
     def _show_support_message(self) -> None:
         support_message = "Please seek reputable expert help if you have serious concerns about a possible spyware attack. Such support is available to human rights defenders and civil society through Amnesty International's Security Lab at https://securitylab.amnesty.org/get-help/?c=mvt"
         if self.detected_count == 0:
             self.log.info(
-                f"NOTE:\nUsing MVT with public indicators of compromise (IOCs) WILL NOT automatically detect advanced attacks.\n\n{support_message}"
+                f"[bold]NOTE:[/bold] Using MVT with public indicators of compromise (IOCs) [bold]WILL NOT[/bold] automatically detect advanced attacks.\n\n{support_message}",
+                extra={"markup": True},
             )
         else:
             self.log.warning(
-                f"NOTE:\nDetected indicators of compromise. Only expert review can confirm if the detected indicators are signs of an attack.\n\n{support_message}"
+                f"[bold]NOTE: Detected indicators of compromise[/bold]. Only expert review can confirm if the detected indicators are signs of an attack.\n\n{support_message}",
+                extra={"markup": True},
             )
 
     def run(self) -> None:
@@ -219,4 +229,6 @@ class Command:
 
         self._store_timeline()
         self._store_info()
+
+        self._show_disable_adb_warning()
         self._show_support_message()

--- a/mvt/common/command.py
+++ b/mvt/common/command.py
@@ -160,6 +160,17 @@ class Command:
     def finish(self) -> None:
         raise NotImplementedError
 
+    def _show_support_message(self) -> None:
+        support_message = "Please seek reputable expert help if you have serious concerns about a possible spyware attack. Such support is available to human rights defenders and civil society through Amnesty International's Security Lab at https://securitylab.amnesty.org/get-help/?c=mvt"
+        if self.detected_count == 0:
+            self.log.info(
+                f"NOTE:\nUsing MVT with public indicators of compromise (IOCs) WILL NOT automatically detect advanced attacks.\n\n{support_message}"
+            )
+        else:
+            self.log.warning(
+                f"NOTE:\nDetected indicators of compromise. Only expert review can confirm if the detected indicators are signs of an attack.\n\n{support_message}"
+            )
+
     def run(self) -> None:
         try:
             self.init()
@@ -208,3 +219,4 @@ class Command:
 
         self._store_timeline()
         self._store_info()
+        self._show_support_message()

--- a/mvt/common/command.py
+++ b/mvt/common/command.py
@@ -164,7 +164,7 @@ class Command:
         """Warn if ADB is enabled"""
         if type(self).__name__ in ["CmdAndroidCheckADB", "CmdAndroidCheckAndroidQF"]:
             self.log.info(
-                "Please disable ADB (Android Debug Bridge) on the device once finished with the acquisition. "
+                "Please disable Developer Options and ADB (Android Debug Bridge) on the device once finished with the acquisition. "
                 "ADB is a powerful tool which can allow unauthorized access to the device."
             )
 


### PR DESCRIPTION
We regularly hear from individuals or groups who have used MVT with public indicators to check their devices for advanced spyware tools. Unfortunately individuals may get a false sense of security if they do not see any matches from the public indicators.  Not all users may fully understand the limitations of MVT to detect recent or advanced attack without expert support and guidance.

This PR updates the documentation to include links to the Amnesty Security Lab website. The PR also adds a log message at the end of each MVT command which explains the limits of MVT and directs non-expert users to seek expert help if they are concerned about spyware targeting.   