### PR TITLE
Fixes datetime issues in iOS SMS parsing

### DIFF
--- a/mvt/ios/modules/mixed/sms.py
+++ b/mvt/ios/modules/mixed/sms.py
@@ -144,7 +144,9 @@ class SMS(IOSExtraction):
 
             # We convert Mac's ridiculous timestamp format.
             message["isodate"] = convert_mactime_to_iso(message["date"])
-            message["isodate_read"] = convert_mactime_to_iso(message["date_read"])
+            if message["date_read"]:
+                message["isodate_read"] = convert_mactime_to_iso(message["date_read"])
+
             message["direction"] = (
                 "sent" if message.get("is_from_me", 0) == 1 else "received"
             )

--- a/mvt/ios/modules/mixed/sms_attachments.py
+++ b/mvt/ios/modules/mixed/sms_attachments.py
@@ -112,8 +112,15 @@ class SMSAttachments(IOSExtraction):
                     value = b64encode(value).decode()
                 attachment[names[index]] = value
 
-            attachment["isodate"] = convert_mactime_to_iso(attachment["created_date"])
-            attachment["start_date"] = convert_mactime_to_iso(attachment["start_date"])
+            if attachment["created_date"]:
+                attachment["isodate"] = convert_mactime_to_iso(
+                    attachment["created_date"]
+                )
+            if attachment["start_date"]:
+                attachment["start_date"] = convert_mactime_to_iso(
+                    attachment["start_date"]
+                )
+
             attachment["direction"] = (
                 "sent" if attachment["is_outgoing"] == 1 else "received"
             )


### PR DESCRIPTION
Since #488, we have to check that dates exists before converting them, which isn't done properly in iOS SMS and SMS Attachments. It should fix #466 but we may have more modules with this issue