### PR TITLE
Run black linter on pull requests

### DIFF
--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -1,5 +1,10 @@
 name: Black
-on: [push]
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
 
 jobs:
   black:


### PR DESCRIPTION
The black linter was only being run on pushes to main and not on opened PRs. We should run on both to avoid linting errors after a PR is merged.