### PR TITLE
Add basic support for IP indicators in MVT

### DIFF
--- a/src/mvt/common/indicators.py
+++ b/src/mvt/common/indicators.py
@@ -14,7 +14,6 @@ import ahocorasick
 from appdirs import user_data_dir
 
 from .url import URL
-import ipaddress
 
 MVT_DATA_FOLDER = user_data_dir("mvt")
 MVT_INDICATORS_FOLDER = os.path.join(MVT_DATA_FOLDER, "indicators")
@@ -109,28 +108,12 @@ class Indicators:
                 ioc_coll_list=collection["domains"],
             )
         if key == "ipv4-addr:value":
-            # Check for cidr notation, and add each ip to the domains collection
-            if "/" in value:
-                try:
-                    network = ipaddress.ip_network(value.strip("'"), strict=False)
-                    for ip in network.hosts():
-                        self._add_indicator(
-                            ioc="'" + str(ip) + "'",
-                            ioc_coll=collection,
-                            ioc_coll_list=collection["domains"],
-                        )
-                except ValueError:
-                    self.log.critical(
-                        "Invalid CIDR notation ipv4-addr:value %s in STIX2 indicator file!", value
-                    )
-                    return
-            else:
-                # Single IP address, add to domains collection
-                self._add_indicator(
-                    ioc=value,
-                    ioc_coll=collection,
-                    ioc_coll_list=collection["domains"],
-                )
+            # We treat IP addresses as simple domains here to ease checks.
+            self._add_indicator(
+                ioc=value.strip(),
+                ioc_coll=collection,
+                ioc_coll_list=collection["domains"],
+            )
         elif key == "process:name":
             self._add_indicator(
                 ioc=value, ioc_coll=collection, ioc_coll_list=collection["processes"]

--- a/src/mvt/common/indicators.py
+++ b/src/mvt/common/indicators.py
@@ -14,6 +14,7 @@ import ahocorasick
 from appdirs import user_data_dir
 
 from .url import URL
+import ipaddress
 
 MVT_DATA_FOLDER = user_data_dir("mvt")
 MVT_INDICATORS_FOLDER = os.path.join(MVT_DATA_FOLDER, "indicators")
@@ -107,6 +108,29 @@ class Indicators:
                 ioc_coll=collection,
                 ioc_coll_list=collection["domains"],
             )
+        if key == "ipv4-addr:value":
+            # Check for cidr notation, and add each ip to the domains collection
+            if "/" in value:
+                try:
+                    network = ipaddress.ip_network(value.strip("'"), strict=False)
+                    for ip in network.hosts():
+                        self._add_indicator(
+                            ioc="'" + str(ip) + "'",
+                            ioc_coll=collection,
+                            ioc_coll_list=collection["domains"],
+                        )
+                except ValueError:
+                    self.log.critical(
+                        "Invalid CIDR notation ipv4-addr:value %s in STIX2 indicator file!", value
+                    )
+                    return
+            else:
+                # Single IP address, add to domains collection
+                self._add_indicator(
+                    ioc=value,
+                    ioc_coll=collection,
+                    ioc_coll_list=collection["domains"],
+                )
         elif key == "process:name":
             self._add_indicator(
                 ioc=value, ioc_coll=collection, ioc_coll_list=collection["processes"]

--- a/tests/artifacts/generate_stix.py
+++ b/tests/artifacts/generate_stix.py
@@ -37,7 +37,7 @@ def generate_test_stix_file(file_path):
     for a in ip_addresses:
         i = Indicator(
             indicator_types=["malicious-activity"],
-            pattern="[ipv4-addr:value='{}']".format(d),
+            pattern="[ipv4-addr:value='{}']".format(a),
             pattern_type="stix",
         )
         res.append(i)

--- a/tests/artifacts/generate_stix.py
+++ b/tests/artifacts/generate_stix.py
@@ -13,6 +13,7 @@ def generate_test_stix_file(file_path):
         os.remove(file_path)
 
     domains = ["example.org"]
+    ip_addresses = ["198.51.100.1"]
     processes = ["Launch"]
     emails = ["foobar@example.org"]
     filenames = ["/var/foobar/txt"]
@@ -28,6 +29,15 @@ def generate_test_stix_file(file_path):
         i = Indicator(
             indicator_types=["malicious-activity"],
             pattern="[domain-name:value='{}']".format(d),
+            pattern_type="stix",
+        )
+        res.append(i)
+        res.append(Relationship(i, "indicates", malware))
+
+    for a in ip_addresses:
+        i = Indicator(
+            indicator_types=["malicious-activity"],
+            pattern="[ipv4-addr:value='{}']".format(d),
             pattern_type="stix",
         )
         res.append(i)

--- a/tests/common/test_indicators.py
+++ b/tests/common/test_indicators.py
@@ -15,8 +15,8 @@ class TestIndicators:
         ind = Indicators(log=logging)
         ind.load_indicators_files([indicator_file], load_default=False)
         assert len(ind.ioc_collections) == 1
-        assert ind.ioc_collections[0]["count"] == 8
-        assert len(ind.ioc_collections[0]["domains"]) == 1
+        assert ind.ioc_collections[0]["count"] == 9
+        assert len(ind.ioc_collections[0]["domains"]) == 2
         assert len(ind.ioc_collections[0]["emails"]) == 1
         assert len(ind.ioc_collections[0]["file_names"]) == 1
         assert len(ind.ioc_collections[0]["processes"]) == 1
@@ -74,6 +74,10 @@ class TestIndicators:
         assert ind.check_url("https://github.com") is None
         assert ind.check_url("https://example.com/") is None
 
+        # Test detecting IP address indicators from STIX.
+        assert ind.check_url("https://198.51.100.1:8080/")
+        assert ind.check_url("https://1.1.1.1/") is None
+
     def test_check_file_hash(self, indicator_file):
         ind = Indicators(log=logging)
         ind.load_indicators_files([indicator_file], load_default=False)
@@ -98,4 +102,4 @@ class TestIndicators:
         os.environ["MVT_STIX2"] = indicator_file
         ind = Indicators(log=logging)
         ind.load_indicators_files([], load_default=False)
-        assert ind.total_ioc_count == 8
+        assert ind.total_ioc_count == 9


### PR DESCRIPTION
This PR reworks #465 which was started by [renini](https://github.com/renini).

The initial PR had support for specifying IP address in CIDR format. I've remove this for now as it could risk making MVT slow if large CIDRs are specified with thousands or millions of IPs. 

This first version supports IP addresses by treated as domains internally in MVT which will automatically be matching in existing `check_domain` and `check_url` functions.

Closes #465.