### PR TITLE
Fix crash when handling empty adb key list

### DIFF
--- a/src/mvt/android/artifacts/dumpsys_adb.py
+++ b/src/mvt/android/artifacts/dumpsys_adb.py
@@ -120,7 +120,7 @@ class DumpsysADBArtifact(AndroidArtifact):
 
         # Calculate key fingerprints for better readability
         key_info = []
-        for user_key in parsed.get("user_keys"):
+        for user_key in parsed.get("user_keys", []):
             user_info = self.calculate_key_info(user_key)
             key_info.append(user_info)
 


### PR DESCRIPTION
This commit fixes a crash in the ADB module when no keys were parsed. We should return an empty list by default.