### PR TITLE
Include default values when parsing tombstone protobuf files

### DIFF
--- a/src/mvt/android/artifacts/tombstone_crashes.py
+++ b/src/mvt/android/artifacts/tombstone_crashes.py
@@ -62,7 +62,7 @@ class TombstoneCrashResult(pydantic.BaseModel):
     process_name: Optional[str] = None
     binary_path: Optional[str] = None
     selinux_label: Optional[str] = None
-    uid: Optional[int] = None
+    uid: int
     signal_info: SignalInfo
     cause: Optional[str] = None
     extra: Optional[str] = None
@@ -124,7 +124,9 @@ class TombstoneCrashArtifact(AndroidArtifact):
         Parse Android tombstone crash files from a protobuf object.
         """
         tombstone_pb = Tombstone().parse(data)
-        tombstone_dict = tombstone_pb.to_dict(betterproto.Casing.SNAKE)
+        tombstone_dict = tombstone_pb.to_dict(
+            betterproto.Casing.SNAKE, include_default_values=True
+        )
 
         # Add some extra metadata
         tombstone_dict["timestamp"] = self._parse_timestamp_string(


### PR DESCRIPTION
This commit fixes bug a where default values were dropped when parsing protobuf tombstone files. This meant that important fields such as UID would be dropped with set to "0", the default value for an integer field.

Passing `include_default_values` seems to fix the issue!