### PR TITLE
Upgrade main dockerfile runtime to ubuntu:24.04

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -103,7 +103,7 @@ RUN git clone https://github.com/libimobiledevice/usbmuxd && cd usbmuxd \
 
 
 # Create main image
-FROM ubuntu:22.04 as main
+FROM ubuntu:24.04 as main
 
 LABEL org.opencontainers.image.url="https://mvt.re"
 LABEL org.opencontainers.image.documentation="https://docs.mvt.re"
@@ -135,8 +135,7 @@ COPY --from=build-usbmuxd /build /
 COPY . mvt/
 RUN apt-get update \
    && apt-get install -y git python3-pip \
-   && PIP_NO_CACHE_DIR=1 pip3 install --upgrade pip \
-   && PIP_NO_CACHE_DIR=1 pip3 install ./mvt \
+   && PIP_NO_CACHE_DIR=1 pip3 install --break-system-packages ./mvt \
    && apt-get remove -y python3-pip git && apt-get autoremove -y \
    && rm -rf /var/lib/apt/lists/* \
    && rm -rf mvt


### PR DESCRIPTION
This is to fix #616. The latest sqlite3 version in the ubuntu:22.04 image is 3.37.2, however recent versions of iOS appear to use version 3.43.2. By upgrading to ubuntu:24.04, it now uses sqlite version 3.45.1.

The build containers don't need to be updated as this is only a runtime dependency. The Dockerfile.ios file does not need to be updated because it uses a different image for its base, which already has sqlite version 3.45.3.