### PR TITLE
Fix issue #574 for a module without IOCs output

### DIFF
--- a/src/mvt/common/cmd_check_iocs.py
+++ b/src/mvt/common/cmd_check_iocs.py
@@ -66,7 +66,7 @@ class CmdCheckIOCS(Command):
                     file_path, log=logging.getLogger(iocs_module.__module__)
                 )
                 if not m:
-                    log.warning('No result from this module, skipping it')
+                    log.warning("No result from this module, skipping it")
                     continue
 
                 if self.iocs.total_ioc_count > 0:

--- a/src/mvt/common/module.py
+++ b/src/mvt/common/module.py
@@ -75,9 +75,7 @@ class MVTModule:
                     log.info('Loaded %d results from "%s"', len(results), json_path)
                 return cls(results=results, log=log)
             except json.decoder.JSONDecodeError as err:
-                log.error(
-                    'Error to decode the json "%s" file: "%s"', json_path, err
-                )
+                log.error('Error to decode the json "%s" file: "%s"', json_path, err)
                 return None
 
     @classmethod


### PR DESCRIPTION
Got the same issue as https://github.com/mvt-project/mvt/issues/574 where a module doesn't have any IOCs output.

Log the module that have no IOCs output, and skip it :)