### PR TITLE
Update global_preferences.py

### DIFF
--- a/src/mvt/ios/modules/mixed/global_preferences.py
+++ b/src/mvt/ios/modules/mixed/global_preferences.py
@@ -43,6 +43,9 @@ class GlobalPreferences(IOSExtraction):
                     self.log.warning("Lockdown mode enabled")
                 else:
                     self.log.warning("Lockdown mode disabled")
+            else: # If the property is not present, it is disabled by default
+                self.log.warning("Lockdown mode disabled")
+
 
     def process_file(self, file_path: str) -> None:
         with open(file_path, "rb") as handle:


### PR DESCRIPTION
Added a warning for lockdown mode when the property is not present

In newer iOS version the Lockdown Service is mandatory, so if the configuration global file does not have the key, it means it's disabled.