### PR TITLE
Run CI tests against Python3.14 too

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.10', '3.11', '3.12', '3.13']
+        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Add Python 3.14 to the supported Python versions, and run tests against this version on GitHub Action.

This will ensure the #707 is resolved.