### PR TITLE
Fix config for Ruff linter in pyproject config and Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,9 @@
 PWD = $(shell pwd)
 
-autofix:
-	ruff format .
-	ruff check --fix .
-
 check: ruff mypy
 
 ruff:
-	ruff format --check .
-	ruff check -q .
+	ruff check .
 
 mypy:
 	mypy

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,7 +80,7 @@ packages = "src"
 addopts = "-ra -q --cov=mvt --cov-report html --junitxml=pytest.xml --cov-report=term-missing:skip-covered"
 testpaths = ["tests"]
 
-[tool.ruff.lint]
+[tool.ruff]
 select = ["C90", "E", "F", "W"] # flake8 default set
 ignore = [
     "E501", # don't enforce line length violations
@@ -95,10 +95,10 @@ ignore = [
     # "E203",  # whitespace-before-punctuation
 ]
 
-[tool.ruff.lint.per-file-ignores]
+[tool.ruff.per-file-ignores]
 "__init__.py" = ["F401"] # unused-import
 
-[tool.ruff.lint.mccabe]
+[tool.ruff.mccabe]
 max-complexity = 10
 
 [tool.setuptools]


### PR DESCRIPTION
The default arguments for ruff seem to have changed. I'm simplifying the Makefile which is used to run local linter and tests during development. 