### PR TITLE
Bump version for release v2.7.0

### DIFF
--- a/src/mvt/common/version.py
+++ b/src/mvt/common/version.py
@@ -3,4 +3,4 @@
 # Use of this software is governed by the MVT License 1.1 that can be found at
 #   https://license.mvt.re/1.1/
 
-MVT_VERSION = "2.6.1"
+MVT_VERSION = "2.7.0"


### PR DESCRIPTION
Bump MVT version to v2.7.0 before tagging a new release.