### PR TITLE
Fix timeline cross run contamination

### DIFF
--- a/src/mvt/common/alerts.py
+++ b/src/mvt/common/alerts.py
@@ -219,7 +219,7 @@ class AlertStore:
         return alerts
 
     def save_timeline(self, timeline_path: str) -> None:
-        with open(timeline_path, "a+", encoding="utf-8") as handle:
+        with open(timeline_path, "w", encoding="utf-8") as handle:
             csvoutput = csv.writer(
                 handle,
                 delimiter=",",

--- a/src/mvt/common/module.py
+++ b/src/mvt/common/module.py
@@ -259,7 +259,7 @@ def save_timeline(timeline: list, timeline_path: str, is_utc: bool = True) -> No
     :param timeline_path: Path to the csv file to store the timeline to
 
     """
-    with open(timeline_path, "a+", encoding="utf-8") as handle:
+    with open(timeline_path, "w", encoding="utf-8") as handle:
         csvoutput = csv.writer(
             handle, delimiter=",", quotechar='"', quoting=csv.QUOTE_ALL, escapechar="\\"
         )


### PR DESCRIPTION
Closes #797 
Switch `save_timeline()` for `timeline.csv` and `alerts_timeline.csv` from append to write mode. Both timelines are fully built in memory before writing, so append only caused silent data contamination across runs.