### PR TITLE
Enforce NETWORK_ACCESS_ALLOWED and NETWORK_TIMEOUT on URL.unshorten

### DIFF
--- a/src/mvt/common/url.py
+++ b/src/mvt/common/url.py
@@ -3,10 +3,15 @@
 # Use of this software is governed by the MVT License 1.1 that can be found at
 #   https://license.mvt.re/1.1/
 
+import logging
 from typing import Optional
 
 import requests
 from tld import get_tld
+
+from .config import settings
+
+log = logging.getLogger(__name__)
 
 SHORTENER_DOMAINS = [
     "0rz.tw",
@@ -375,7 +380,16 @@ class URL:
 
     def unshorten(self) -> Optional[str]:
         """Unshorten the URL by requesting an HTTP HEAD response."""
-        res = requests.head(self.url)
+
+        if settings.NETWORK_ACCESS_ALLOWED is False:
+            log.info(
+                "Network access disabled (MVT_NETWORK_ACCESS_ALLOWED=False), "
+                "skipping unshorten for %s",
+                self.url,
+            )
+            return ""
+
+        res = requests.head(self.url, timeout=settings.NETWORK_TIMEOUT)
         if str(res.status_code).startswith("30"):
             return res.headers["Location"]
 


### PR DESCRIPTION
Closes #799 
Short circuit `unshorten()` when env variable NETWORK_ACCESS_ALLOWED is False, and apply NETWORK_TIMEOUT to the HEAD request.