### PR TITLE
Fix dumpsys accessibility service alerts

### DIFF
--- a/src/mvt/android/artifacts/dumpsys_accessibility.py
+++ b/src/mvt/android/artifacts/dumpsys_accessibility.py
@@ -10,16 +10,20 @@ from .artifact import AndroidArtifact
 
 class DumpsysAccessibilityArtifact(AndroidArtifact):
     def check_indicators(self) -> None:
-        if not self.indicators:
-            return
-
         for result in self.results:
-            ioc_match = self.indicators.check_app_id(result["package_name"])
-            if ioc_match:
-                self.alertstore.critical(
-                    ioc_match.message, "", result, matched_indicator=ioc_match.ioc
+            if self.indicators:
+                ioc_match = self.indicators.check_app_id(result["package_name"])
+                if ioc_match:
+                    self.alertstore.critical(
+                        ioc_match.message, "", result, matched_indicator=ioc_match.ioc
+                    )
+                    continue
+
+            self.alertstore.medium(
+                f'Found accessibility service: "{result["service"]}"',
+                "",
+                result,
                 )
-                continue
 
     def parse(self, content: str) -> None:
         """

--- a/tests/android/test_artifact_dumpsys_accessibility.py
+++ b/tests/android/test_artifact_dumpsys_accessibility.py
@@ -5,6 +5,7 @@
 import logging
 
 from mvt.android.artifacts.dumpsys_accessibility import DumpsysAccessibilityArtifact
+from mvt.common.alerts import AlertLevel
 from mvt.common.indicators import Indicators
 
 from ..utils import get_artifact
@@ -38,6 +39,19 @@ class TestDumpsysAccessibilityArtifact:
         assert da.results[0]["package_name"] == "com.malware.accessibility"
         assert da.results[0]["service"] == "com.malware.service.malwareservice"
 
+    def test_accessibility_service_alert(self):
+        da = DumpsysAccessibilityArtifact()
+        file = get_artifact("android_data/dumpsys_accessibility_v14_or_later.txt")
+        with open(file) as f:
+            data = f.read()
+        da.parse(data)
+
+        da.check_indicators()
+
+        assert len(da.alertstore.alerts) == 1
+        assert da.alertstore.alerts[0].level == AlertLevel.MEDIUM
+        assert da.alertstore.alerts[0].event == da.results[0]
+
     def test_ioc_check(self, indicator_file):
         da = DumpsysAccessibilityArtifact()
         file = get_artifact("android_data/dumpsys_accessibility.txt")
@@ -51,4 +65,12 @@ class TestDumpsysAccessibilityArtifact:
         da.indicators = ind
         assert len(da.alertstore.alerts) == 0
         da.check_indicators()
-        assert len(da.alertstore.alerts) == 1
+        assert len(da.alertstore.alerts) == len(da.results)
+        assert da.alertstore.count(AlertLevel.MEDIUM) == 3
+        assert da.alertstore.count(AlertLevel.CRITICAL) == 1
+        critical_alert = next(
+            alert
+            for alert in da.alertstore.alerts
+            if alert.level == AlertLevel.CRITICAL
+        )
+        assert critical_alert.event["package_name"] == "com.sec.android.app.camera"


### PR DESCRIPTION
## Summary

- emit a medium alert for accessibility services parsed from `dumpsys accessibility`
- preserve critical severity for services matching an IOC without adding a duplicate medium alert
- add regression coverage for the no-IOC and IOC paths

## Root cause

`DumpsysAccessibilityArtifact.check_indicators()` returned immediately when no IOC collection was loaded. As a result, parsed accessibility services were included in module results but never surfaced through the structured alert store.

This change adds the expected heuristic alert independently of IOC availability while keeping IOC matches at critical severity.

Fixes #802