### PR TITLE
Document network access options

### DIFF
--- a/docs/iocs.md
+++ b/docs/iocs.md
@@ -34,6 +34,25 @@ It is also possible to load STIX2 files automatically from the environment varia
 export MVT_STIX2="/home/user/IOC1.stix2:/home/user/IOC2.stix2"
 ```
 
+## Network Access
+
+When checking URL indicators, MVT follows recognized shortened URLs with an
+HTTP `HEAD` request. The following environment variables control these
+requests:
+
+- `MVT_NETWORK_ACCESS_ALLOWED` enables or disables network requests. It defaults
+  to `true`. Set it to `false` to prevent MVT from attempting to resolve
+  shortened URLs.
+- `MVT_NETWORK_TIMEOUT` sets the request timeout in seconds. It defaults to
+  `15`.
+
+For example, to run IOC checks without resolving shortened URLs:
+
+```bash
+MVT_NETWORK_ACCESS_ALLOWED=false mvt-ios check-iocs \
+    --iocs ~/iocs/malware.stix2 /path/to/iphone/output/
+```
+
 ## STIX2 Support
 
 So far MVT implements only a subset of [STIX2 specifications](https://docs.oasis-open.org/cti/stix/v2.1/csprd01/stix-v2.1-csprd01.html):
@@ -53,6 +72,5 @@ So far MVT implements only a subset of [STIX2 specifications](https://docs.oasis
 You can automaticallly download the latest public indicator files with the command `mvt-ios download-iocs` or `mvt-android download-iocs`. These commands download the list of indicators from the [mvt-indicators](https://github.com/mvt-project/mvt-indicators/blob/main/indicators.yaml) repository and store them in the [appdir](https://pypi.org/project/appdirs/) folder. They are then loaded automatically by MVT.
 
 Please [open an issue](https://github.com/mvt-project/mvt/issues/) to suggest new sources of STIX-formatted IOCs.
-
 
 


### PR DESCRIPTION
## Summary

Document the environment variables that control network requests while checking URL indicators:

- `MVT_NETWORK_ACCESS_ALLOWED`
- `MVT_NETWORK_TIMEOUT`

The documentation includes their defaults and an example for running IOC checks without resolving shortened URLs.

## Context

This addresses the documentation gap raised in the discussion on #800.