### PR TITLE
Run mypy on pull requests

### DIFF
--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -1,5 +1,8 @@
 name: Mypy
-on: workflow_dispatch
+on:
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
 
 jobs:
   mypy_py3:


### PR DESCRIPTION
## Summary

Run the existing Mypy workflow for pull requests targeting `main`, while preserving manual workflow dispatch.

## Rationale

Mypy is part of the repository's required local checks, but the GitHub Actions workflow only supported manual dispatch. As a result, typing regressions could pass the automatic pull request checks.
