### PR TITLE
intrusion_logs: alert on certificate events and run heuristics without IOCs

### DIFF
--- a/src/mvt/android/modules/intrusion_logs/security_event.py
+++ b/src/mvt/android/modules/intrusion_logs/security_event.py
@@ -422,16 +422,22 @@ class SecurityEvent(IntrusionLogsModule):
                 result,
             )
 
-        # Flag certificate authority installations (potential MITM)
+        # Flag successful certificate authority installations (potential
+        # MITM); a missing success field is treated as installed
         if "cert_authority_installed" in result:
             cert_info = result["cert_authority_installed"]
-            self.alertstore.medium(
-                "Certificate authority installed: "
-                f"{cert_info.get('subject', 'unknown')} "
-                f"(success: {cert_info.get('success', 'unknown')})",
-                result.get("timestamp") or "",
-                result,
-            )
+            if cert_info.get("success", True):
+                self.alertstore.medium(
+                    "Certificate authority installed: "
+                    f"{cert_info.get('subject', 'unknown')}",
+                    result.get("timestamp") or "",
+                    result,
+                )
+            else:
+                self.log.warning(
+                    "Failed certificate authority install attempt: %s",
+                    cert_info.get("subject", "unknown"),
+                )
 
         # Flag wipe failures
         if "wipe_failure" in result:

--- a/src/mvt/android/modules/intrusion_logs/security_event.py
+++ b/src/mvt/android/modules/intrusion_logs/security_event.py
@@ -302,10 +302,15 @@ class SecurityEvent(IntrusionLogsModule):
 
     def check_indicators(self) -> None:
         """Check security events against indicators of compromise."""
-        if not self.indicators:
-            return
-
         for result in self.results:
+            # Heuristic alerts are intrinsic to the event, so they run even
+            # when no indicator set is loaded.
+            self._check_security_heuristics(result)
+
+            # The remaining checks match events against loaded indicators.
+            if not self.indicators:
+                continue
+
             # Check app process start events for suspicious package names
             if "app_process_start" in result:
                 process_info = result["app_process_start"]
@@ -389,59 +394,66 @@ class SecurityEvent(IntrusionLogsModule):
                                 matched_indicator=ioc.ioc,
                             )
 
-            # Flag failed cryptographic operations as potentially suspicious
-            if "key_generated" in result:
-                if not result["key_generated"].get("success", True):
-                    self.log.warning(
-                        "Failed key generation detected for key_id: %s",
-                        result["key_generated"].get("key_id", "unknown"),
-                    )
-
-            # Flag certificate validation failures
-            if "cert_validation_failure" in result:
+    def _check_security_heuristics(self, result: dict) -> None:
+        """Raise alerts for events that are intrinsically suspicious,
+        independent of any loaded indicators."""
+        # Flag failed cryptographic operations as potentially suspicious
+        if "key_generated" in result:
+            if not result["key_generated"].get("success", True):
                 self.log.warning(
-                    "Certificate validation failure detected: %s",
-                    result.get("cert_validation_failure"),
+                    "Failed key generation detected for key_id: %s",
+                    result["key_generated"].get("key_id", "unknown"),
                 )
 
-            # Flag key integrity violations
-            if "key_integrity_violation" in result:
+        # Flag certificate validation failures
+        if "cert_validation_failure" in result:
+            self.alertstore.medium(
+                "Certificate validation failure detected: "
+                f"{result.get('cert_validation_failure')}",
+                result.get("timestamp") or "",
+                result,
+            )
+
+        # Flag key integrity violations
+        if "key_integrity_violation" in result:
+            self.alertstore.medium(
+                f"Key integrity violation detected: {result.get('key_integrity_violation')}",
+                result.get("timestamp") or "",
+                result,
+            )
+
+        # Flag certificate authority installations (potential MITM)
+        if "cert_authority_installed" in result:
+            cert_info = result["cert_authority_installed"]
+            self.alertstore.medium(
+                "Certificate authority installed: "
+                f"{cert_info.get('subject', 'unknown')} "
+                f"(success: {cert_info.get('success', 'unknown')})",
+                result.get("timestamp") or "",
+                result,
+            )
+
+        # Flag wipe failures
+        if "wipe_failure" in result:
+            self.alertstore.medium(
+                "Device wipe failure detected",
+                result.get("timestamp") or "",
+                result,
+            )
+
+        # Flag crypto self test failures
+        if "crypto_self_test_completed" in result:
+            test_result = result["crypto_self_test_completed"]
+            if isinstance(test_result, dict):
+                success = test_result.get("success", True)
+            else:
+                success = test_result == 1
+            if not success:
                 self.alertstore.medium(
-                    f"Key integrity violation detected: {result.get('key_integrity_violation')}",
+                    "Cryptographic self test failed",
                     result.get("timestamp") or "",
                     result,
                 )
-
-            # Flag certificate authority installations (potential MITM)
-            if "cert_authority_installed" in result:
-                cert_info = result["cert_authority_installed"]
-                self.log.warning(
-                    "Certificate authority installed: %s (success: %s)",
-                    cert_info.get("subject", "unknown"),
-                    cert_info.get("success", "unknown"),
-                )
-
-            # Flag wipe failures
-            if "wipe_failure" in result:
-                self.alertstore.medium(
-                    "Device wipe failure detected",
-                    result.get("timestamp") or "",
-                    result,
-                )
-
-            # Flag crypto self test failures
-            if "crypto_self_test_completed" in result:
-                test_result = result["crypto_self_test_completed"]
-                if isinstance(test_result, dict):
-                    success = test_result.get("success", True)
-                else:
-                    success = test_result == 1
-                if not success:
-                    self.alertstore.medium(
-                        "Cryptographic self test failed",
-                        result.get("timestamp") or "",
-                        result,
-                    )
 
     def serialize(self, record: dict) -> Union[dict, list]:
         """Serialize a security event record for timeline output."""

--- a/tests/android/test_intrusion_logs.py
+++ b/tests/android/test_intrusion_logs.py
@@ -6,6 +6,7 @@
 import json
 import logging
 
+import pytest
 from click.testing import CliRunner
 
 from mvt.android.cli import check_intrusion_logs
@@ -179,6 +180,27 @@ def test_cert_authority_installed_raises_medium_alert_without_indicators():
     assert alerts[0].level == AlertLevel.MEDIUM
     assert "Certificate authority installed" in alerts[0].message
     assert "Unexpected Root CA" in alerts[0].message
+
+
+# Exported logs encode success as a JSON bool, raw SecurityLog as int 0/1.
+@pytest.mark.parametrize("success", [False, 0])
+def test_failed_cert_authority_install_does_not_alert(success, caplog):
+    with caplog.at_level(logging.WARNING):
+        alerts = _run_security_heuristics(
+            [
+                {
+                    "timestamp": "2024-01-01 00:00:00.000",
+                    "cert_authority_installed": {
+                        "subject": "CN=Unexpected Root CA",
+                        "success": success,
+                    },
+                }
+            ]
+        )
+
+    assert alerts == []
+    assert "Failed certificate authority install attempt" in caplog.text
+    assert "Unexpected Root CA" in caplog.text
 
 
 def test_cert_validation_failure_raises_medium_alert_without_indicators():

--- a/tests/android/test_intrusion_logs.py
+++ b/tests/android/test_intrusion_logs.py
@@ -12,6 +12,7 @@ from mvt.android.cli import check_intrusion_logs
 from mvt.android.cmd_check_intrusion_logs import CmdAndroidCheckIntrusionLogs
 from mvt.android.modules.intrusion_logs.base import IntrusionLogsModule
 from mvt.android.modules.intrusion_logs.security_event import SecurityEvent
+from mvt.common.alerts import AlertLevel
 
 
 def _write_ndjson(path, records):
@@ -152,3 +153,61 @@ def test_check_intrusion_logs_cli_lists_modules(tmp_path):
     assert "DnsEvent" in result.output
     assert "ConnectEvent" in result.output
     assert "SecurityEvent" in result.output
+
+
+def _run_security_heuristics(results):
+    # No indicators loaded: heuristic alerts must still fire.
+    module = SecurityEvent(results=results)
+    module.check_indicators()
+    return module.alertstore.alerts
+
+
+def test_cert_authority_installed_raises_medium_alert_without_indicators():
+    alerts = _run_security_heuristics(
+        [
+            {
+                "timestamp": "2024-01-01 00:00:00.000",
+                "cert_authority_installed": {
+                    "subject": "CN=Unexpected Root CA",
+                    "success": True,
+                },
+            }
+        ]
+    )
+
+    assert len(alerts) == 1
+    assert alerts[0].level == AlertLevel.MEDIUM
+    assert "Certificate authority installed" in alerts[0].message
+    assert "Unexpected Root CA" in alerts[0].message
+
+
+def test_cert_validation_failure_raises_medium_alert_without_indicators():
+    alerts = _run_security_heuristics(
+        [
+            {
+                "timestamp": "2024-01-01 00:00:00.000",
+                "cert_validation_failure": "chain validation failed",
+            }
+        ]
+    )
+
+    assert len(alerts) == 1
+    assert alerts[0].level == AlertLevel.MEDIUM
+    assert "Certificate validation failure" in alerts[0].message
+
+
+def test_security_heuristics_fire_when_no_indicators_loaded():
+    # check_indicators() previously returned early with no indicators loaded,
+    # so none of the heuristic alerts fired on a default run.
+    alerts = _run_security_heuristics(
+        [
+            {"timestamp": "2024-01-01 00:00:00.000", "wipe_failure": {"reason": "x"}},
+            {
+                "timestamp": "2024-01-01 00:00:00.000",
+                "key_integrity_violation": {"key_id": "k1"},
+            },
+        ]
+    )
+
+    assert len(alerts) == 2
+    assert all(alert.level == AlertLevel.MEDIUM for alert in alerts)


### PR DESCRIPTION
## Summary

- run `SecurityEvent` heuristic alerts independently of IOC availability, so
  they fire on a default run with no indicator set loaded
- surface `cert_authority_installed` and `cert_validation_failure` through the
  alert store at medium severity, matching their sibling events
- add regression coverage for the certificate alerts and for heuristics firing
  with no indicators loaded

## Root cause

`SecurityEvent.check_indicators()` returned immediately when no indicator set
was loaded. Because `check_indicators()` is always called, a default
`check-intrusion-logs` run produced none of the module's heuristic alerts:
key-integrity violations, wipe failures, crypto self-test failures, and the
certificate events. Separately, `cert_authority_installed` and
`cert_validation_failure` only emitted `log.warning` while sibling events
called `alertstore.medium`, so a root CA installation (potential MITM) and a
certificate validation failure never reached the alert report.

This mirrors the accessibility fix in #807: heuristic alerts now run
independently of IOC availability, while IOC matching stays gated on a loaded
indicator set.
