### PR TITLE
Fix intrusion log event ID parsing

### DIFF
--- a/src/mvt/android/modules/intrusion_logs/security_event.py
+++ b/src/mvt/android/modules/intrusion_logs/security_event.py
@@ -264,6 +264,7 @@ SECURITY_EVENT_TAGS = {
 }
 
 SECURITY_EVENT_METADATA_KEYS = {
+    "event_id",
     "event_time",
     "event_type",
     "timestamp",

--- a/tests/android/test_intrusion_logs.py
+++ b/tests/android/test_intrusion_logs.py
@@ -143,6 +143,58 @@ def test_check_intrusion_logs_parses_core_and_unknown_security_events(
     assert "Please open an issue on GitHub" in caplog.text
 
 
+def test_check_intrusion_logs_treats_event_id_as_security_event_metadata(
+    tmp_path, caplog
+):
+    _write_ndjson(
+        tmp_path / "intrusion.txt",
+        [
+            {
+                "security_event": {
+                    "event_id": 191,
+                    "event_time": 1_700_000_002_000_000_000,
+                    "keyguard_dismiss_auth_attempt": {
+                        "success": True,
+                        "method_strength": 0,
+                    },
+                }
+            },
+            {
+                "security_event": {
+                    "event_id": 192,
+                    "event_time": 1_700_000_003_000_000_000,
+                    "keyguard_dismissed": {},
+                }
+            },
+        ],
+    )
+
+    with caplog.at_level(logging.WARNING):
+        cmd = CmdAndroidCheckIntrusionLogs(target_path=str(tmp_path))
+        cmd.run()
+
+    security_module = next(
+        module for module in cmd.executed if isinstance(module, SecurityEvent)
+    )
+    assert security_module.event_type_counts == {
+        "keyguard_dismiss_auth_attempt": 1,
+        "keyguard_dismissed": 1,
+    }
+    assert [event["event_id"] for event in security_module.results] == [191, 192]
+
+    keyguard_events = {
+        event["event"]: event
+        for event in cmd.timeline
+        if event["event"]
+        in {"keyguard_dismiss_auth_attempt", "keyguard_dismissed"}
+    }
+    assert "Auth attempt: Success" in keyguard_events[
+        "keyguard_dismiss_auth_attempt"
+    ]["data"]
+    assert keyguard_events["keyguard_dismissed"]["data"] == "Keyguard dismissed"
+    assert "unknown intrusion logging security event type(s): event_id" not in caplog.text
+
+
 def test_check_intrusion_logs_cli_lists_modules(tmp_path):
     _write_ndjson(tmp_path / "intrusion.txt", [])
 


### PR DESCRIPTION
## Summary

- treat `event_id` as security-event envelope metadata
- preserve the event ID while detecting the actual security-event subtype
- add regression coverage for the Pixel keyguard events reported in #813

## Root cause

Security event subtype detection selects the first key that is not listed as metadata. Pixel intrusion logs include `event_id` before keys such as `keyguard_dismiss_auth_attempt`, so MVT classified the event as `event_id`. This produced a false unknown-event warning and incorrect timeline output.

## Impact

Security events containing `event_id` are now counted and serialized under their real subtype. Genuine unknown security-event tags continue to produce warnings.

Fixes #813