### PR TITLE
Suppress benign PinStorage key generation warning

### DIFF
--- a/src/mvt/android/modules/intrusion_logs/security_event.py
+++ b/src/mvt/android/modules/intrusion_logs/security_event.py
@@ -270,6 +270,11 @@ SECURITY_EVENT_METADATA_KEYS = {
     "timestamp",
 }
 
+# Known platform failures that remain in the timeline but do not need a warning.
+KNOWN_BENIGN_KEY_GENERATION_FAILURES = {
+    ("PinStorage_crossReboot_key", 1001),
+}
+
 
 class SecurityEvent(IntrusionLogsModule):
     """This module analyzes security events from intrusion logs."""
@@ -400,10 +405,17 @@ class SecurityEvent(IntrusionLogsModule):
         independent of any loaded indicators."""
         # Flag failed cryptographic operations as potentially suspicious
         if "key_generated" in result:
-            if not result["key_generated"].get("success", True):
+            key_info = result["key_generated"]
+            key_id = key_info.get("key_id", "unknown")
+            uid = key_info.get("uid")
+            is_known_benign_failure = (
+                key_id,
+                uid,
+            ) in KNOWN_BENIGN_KEY_GENERATION_FAILURES
+            if not key_info.get("success", True) and not is_known_benign_failure:
                 self.log.warning(
                     "Failed key generation detected for key_id: %s",
-                    result["key_generated"].get("key_id", "unknown"),
+                    key_id,
                 )
 
         # Flag certificate validation failures

--- a/tests/android/test_intrusion_logs.py
+++ b/tests/android/test_intrusion_logs.py
@@ -215,6 +215,52 @@ def _run_security_heuristics(results):
     return module.alertstore.alerts
 
 
+@pytest.mark.parametrize("success", [False, 0])
+def test_known_pinstorage_key_generation_failure_does_not_warn(success, caplog):
+    record = {
+        "timestamp": "2026-06-17 15:31:02.014",
+        "key_generated": {
+            "success": success,
+            "key_id": "PinStorage_crossReboot_key",
+            "uid": 1001,
+        },
+    }
+
+    with caplog.at_level(logging.WARNING):
+        _run_security_heuristics([record])
+
+    assert "Failed key generation detected" not in caplog.text
+
+    timeline_event = SecurityEvent().serialize(record)
+    assert timeline_event["event"] == "key_generated"
+    assert "Key generation failed: PinStorage_crossReboot_key" in timeline_event["data"]
+
+
+@pytest.mark.parametrize(
+    ("key_id", "uid"),
+    [
+        ("PinStorage_crossReboot_key", 10_000),
+        ("another_key", 1001),
+    ],
+)
+def test_other_key_generation_failures_still_warn(key_id, uid, caplog):
+    with caplog.at_level(logging.WARNING):
+        _run_security_heuristics(
+            [
+                {
+                    "timestamp": "2026-06-17 15:31:02.014",
+                    "key_generated": {
+                        "success": False,
+                        "key_id": key_id,
+                        "uid": uid,
+                    },
+                }
+            ]
+        )
+
+    assert f"Failed key generation detected for key_id: {key_id}" in caplog.text
+
+
 def test_cert_authority_installed_raises_medium_alert_without_indicators():
     alerts = _run_security_heuristics(
         [


### PR DESCRIPTION
## Summary

- suppress the known `PinStorage_crossReboot_key` generation warning only when it is owned by Android's Telephony UID 1001
- retain the failed key-generation event in timeline output
- continue warning for the same alias from other UIDs and for other Telephony key failures

Android Telephony creates this key for platform-managed SIM PIN handling across reboots. A failed creation can affect that feature, but this specific system-owned event is not a forensic compromise signal and should not produce a noisy MVT warning.

Closes #826
