### PR TITLE
fix: use exact package match in bugreport receiver check

### DIFF
--- a/src/mvt/android/modules/bugreport/dumpsys_receivers.py
+++ b/src/mvt/android/modules/bugreport/dumpsys_receivers.py
@@ -39,9 +39,9 @@ class DumpsysReceivers(DumpsysReceiversArtifact, BugReportModule):
         for result in self.results:
             if self.indicators:
                 receiver_name = self.results[result][0]["receiver"]
+                package_name = receiver_name.split("/", 1)[0]
 
-                # return IoC if the stix2 process name a substring of the receiver name
-                ioc_match = self.indicators.check_receiver_prefix(receiver_name)
+                ioc_match = self.indicators.check_app_id(package_name)
                 if ioc_match:
                     self.alertstore.critical(
                         ioc_match.message,

--- a/src/mvt/common/indicators.py
+++ b/src/mvt/common/indicators.py
@@ -727,29 +727,6 @@ class Indicators:
 
         return None
 
-    def check_receiver_prefix(
-        self, receiver_name: str
-    ) -> Optional[IndicatorMatch]:
-        """Check the provided receiver name against the list of indicators.
-        An IoC match is detected when a substring of the receiver matches the indicator.
-
-        :param receiver_name: Receiver name to check against app ID indicators
-        :type receiver_name: str
-        :returns: IndicatorMatch if matched, otherwise None
-
-        """
-        if not receiver_name:
-            return None
-
-        for ioc in self.get_iocs("app_ids"):
-            if ioc.value.lower() in receiver_name.lower():
-                return IndicatorMatch(
-                    ioc=ioc,
-                    message=f'Found a known suspicious receiver with name "{receiver_name}" matching indicators from "{ioc.name}"',
-                )
-
-        return None
-
     def check_android_property_name(
         self, property_name: str
     ) -> Optional[IndicatorMatch]:

--- a/tests/common/test_indicators.py
+++ b/tests/common/test_indicators.py
@@ -172,6 +172,15 @@ class TestIndicators:
         assert ind.check_android_property_name("sys.foobar")
         assert ind.check_android_property_name("sys.soundsokay") is None
 
+    def test_check_app_id_no_substring_match(self, indicator_file):
+        ind = Indicators(log=logging)
+        ind.load_indicators_files([indicator_file], load_default=False)
+        ind.ioc_collections[0]["app_ids"].append("com.android.services")
+
+        assert ind.check_app_id("com.android.services") is not None
+        assert ind.check_app_id("com.android.phone") is None
+        assert ind.check_app_id("com.android.services.telephony") is None
+
     def test_env_stix(self, indicator_file):
         os.environ["MVT_STIX2"] = indicator_file
         settings.__init__()  # Reset settings


### PR DESCRIPTION
The check_receiver_prefix method used unanchored substring matching, causing false CRITICAL alerts when a legitimate AOSP receiver class path contained an indicator value as a substring (e.g. TheOneSpy's "com.android.services" matching inside com.android.phone's SIP telephony receiver).

Replace with check_app_id on the extracted package name, consistent with the artifact module's approach. Remove the now-unused check_receiver_prefix method.

Fixes #803

AI assisted 


---
Note: this replaces #812, which GitHub auto-closed when I deleted my old fork during personal cleanup (deleting a fork silently closes its open PRs). Same commit and same state as before; nothing about the change has been modified.