### PR TITLE
Skip resolving Google Maps short URLs

### DIFF
--- a/src/mvt/common/url.py
+++ b/src/mvt/common/url.py
@@ -5,6 +5,7 @@
 
 import logging
 from typing import Optional
+from urllib.parse import urlparse
 
 import requests
 from tld import get_tld
@@ -373,6 +374,10 @@ class URL:
         :rtype: bool
 
         """
+        parsed_url = urlparse(self.url if "://" in self.url else f"//{self.url}")
+        if self.domain.lower() == "goo.gl" and parsed_url.path.startswith("/maps/"):
+            return False
+
         if self.domain.lower() in SHORTENER_DOMAINS:
             self.is_shortened = True
 

--- a/tests/common/test_indicators.py
+++ b/tests/common/test_indicators.py
@@ -80,6 +80,14 @@ class TestIndicators:
         assert ind.check_url("https://198.51.100.1:8080/")
         assert ind.check_url("https://1.1.1.1/") is None
 
+    def test_google_maps_short_url_is_not_resolved(self, indicator_file, mocker):
+        head_request = mocker.patch("mvt.common.url.requests.head")
+        ind = Indicators(log=logging)
+        ind.load_indicators_files([indicator_file], load_default=False)
+
+        assert ind.check_url("https://goo.gl/maps/example") is None
+        head_request.assert_not_called()
+
     def test_check_file_hash(self, indicator_file):
         ind = Indicators(log=logging)
         ind.load_indicators_files([indicator_file], load_default=False)

--- a/tests/common/test_url.py
+++ b/tests/common/test_url.py
@@ -1,0 +1,24 @@
+# Mobile Verification Toolkit (MVT)
+# Copyright (c) 2021-2023 The MVT Authors.
+# Use of this software is governed by the MVT License 1.1 that can be found at
+#   https://license.mvt.re/1.1/
+
+import pytest
+
+from mvt.common.url import URL
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "https://goo.gl/maps/example",
+        "http://goo.gl/maps/example?entry=message",
+        "goo.gl/maps/example",
+    ],
+)
+def test_google_maps_url_is_not_shortened(url):
+    assert URL(url).check_if_shortened() is False
+
+
+def test_other_google_short_url_is_shortened():
+    assert URL("https://goo.gl/example").check_if_shortened() is True


### PR DESCRIPTION
## Summary

- treat `goo.gl/maps/...` links as regular URLs instead of generic shortened URLs
- avoid unnecessary HTTP HEAD requests for Google Maps links found in messages
- retain URL-shortener handling for other `goo.gl` links

## Root cause

MVT classified every URL on `goo.gl` as shortened, so indicator checks attempted to resolve Google Maps links even though those links redirect to `maps.google.com` and do not add useful security context.

## Validation

- `make check`
- `make test-ci` (178 passed, 1 skipped)

Closes mvt-project/mvt-private#76
