### PR TITLE
Fix text tombstone crashing thread parsing

### DIFF
--- a/src/mvt/android/artifacts/tombstone_crashes.py
+++ b/src/mvt/android/artifacts/tombstone_crashes.py
@@ -206,6 +206,11 @@ class TombstoneCrashArtifact(AndroidArtifact):
         return True
 
     def _load_pid_line(self, line: str, tombstone: dict) -> bool:
+        # The first pid line identifies the crashing thread. Full text tombstones
+        # contain additional pid lines for the other threads in the process.
+        if "pid" in tombstone:
+            return True
+
         try:
             parts = line.split(" >>> ") if " >>> " in line else line.split(">>>")
             process_info = parts[0]

--- a/tests/android/test_artifact_tombstones.py
+++ b/tests/android/test_artifact_tombstones.py
@@ -42,6 +42,32 @@ class TestTombstoneCrashArtifact:
         assert len(tombstone_artifact.results) == 1
         self.validate_tombstone_result(tombstone_artifact.results[0])
 
+    def test_text_tombstone_keeps_crashing_thread(self):
+        tombstone_artifact = TombstoneCrashArtifact()
+        artifact_path = "android_data/tombstone_process.txt"
+        file = get_artifact(artifact_path)
+        with open(file, "rb") as f:
+            data = f.read()
+
+        data += (
+            b"\npid: 25541, tid: 31896, name: worker-thread"
+            b"  >>> /vendor/bin/other <<<\n"
+        )
+        tombstone_artifact.parse(
+            os.path.basename(artifact_path),
+            datetime.datetime(2023, 4, 12, 12, 32, 40, 518290),
+            data,
+        )
+
+        result = tombstone_artifact.results[0]
+        assert result["pid"] == 25541
+        assert result["tid"] == 21307
+        assert result["process_name"] == "mtk.ape.decoder"
+        assert (
+            result["binary_path"]
+            == "/vendor/bin/hw/android.hardware.media.c2@1.2-mediatek"
+        )
+
     @pytest.mark.skip(reason="Not implemented yet")
     def test_tombtone_kernel_parsing(self):
         tombstone_artifact = TombstoneCrashArtifact()


### PR DESCRIPTION
## Summary

- retain the crashing thread identity from the first `pid` header in text tombstones
- ignore subsequent thread headers when setting the PID, TID, process name, and binary path
- add regression coverage for tombstones containing additional dumped threads

Android text tombstones repeat `pid`, `tid`, and thread-name headers for every dumped thread. The parser previously processed every header and overwrote the crash metadata, causing the last dumped thread to be reported as the crashing thread.

Closes #847
