### PR TITLE
Handle mis-indented dumpsys receiver actions

### DIFF
--- a/src/mvt/android/artifacts/dumpsys_receivers.py
+++ b/src/mvt/android/artifacts/dumpsys_receivers.py
@@ -96,6 +96,18 @@ class DumpsysReceiversArtifact(AndroidArtifact):
                 self.results[intent] = []
                 continue
 
+            parts = line.strip().split(" ")
+            if len(parts) < 2:
+                # A single-token line here is not a receiver. Real dumpstate
+                # output can print an action header mis-indented (observed with
+                # 15 leading spaces instead of 6), which used to raise
+                # IndexError and abort the whole module. Treat a trailing-colon
+                # token as the next action, skip anything else.
+                if parts[0].endswith(":"):
+                    intent = parts[0][:-1]
+                    self.results.setdefault(intent, [])
+                continue
+
             # If we are not in an intent block yet, skip.
             if not intent:
                 continue
@@ -109,7 +121,7 @@ class DumpsysReceiversArtifact(AndroidArtifact):
 
             # If we got this far, we are processing receivers for the
             # activities we are interested in.
-            receiver = line.strip().split(" ")[1]
+            receiver = parts[1]
             package_name = receiver.split("/")[0]
 
             self.results[intent].append(

--- a/tests/android/test_artifact_dumpsys_receivers.py
+++ b/tests/android/test_artifact_dumpsys_receivers.py
@@ -31,6 +31,44 @@ class TestDumpsysReceiversArtifact:
             == "com.android.storagemanager"
         )
 
+    def test_parsing_misindented_action(self):
+        dr = DumpsysReceiversArtifact()
+        data = """\
+Receiver Resolver Table:
+  Non-Data Actions:
+      android.app.action.ENTER_CAR_MODE:
+        b5b40f6 com.google.android.projection.gearhead/.CarModeBroadcastReceiver
+               android.intent.action.MY_PACKAGE_REPLACED:
+        e7706c1 com.psycatgames.nhiegame/.ScheduledNotificationBootReceiver
+"""
+
+        dr.parse(data)
+
+        assert (
+            dr.results["android.intent.action.MY_PACKAGE_REPLACED"][0][
+                "package_name"
+            ]
+            == "com.psycatgames.nhiegame"
+        )
+
+    def test_parsing_misindented_first_action(self):
+        dr = DumpsysReceiversArtifact()
+        data = """\
+Receiver Resolver Table:
+  Non-Data Actions:
+               android.intent.action.MY_PACKAGE_REPLACED:
+        e7706c1 com.psycatgames.nhiegame/.ScheduledNotificationBootReceiver
+"""
+
+        dr.parse(data)
+
+        assert (
+            dr.results["android.intent.action.MY_PACKAGE_REPLACED"][0][
+                "package_name"
+            ]
+            == "com.psycatgames.nhiegame"
+        )
+
     def test_ioc_check(self, indicator_file):
         dr = DumpsysReceiversArtifact()
         file = get_artifact("android_data/dumpsys_packages.txt")


### PR DESCRIPTION
Closes #851

Android bugreports can contain action headers with deeper indentation than the usual six spaces. `DumpsysReceiversArtifact` treated those lines as receiver rows and indexed a nonexistent second token, aborting the module before it could save results or check indicators.

Recognize single-token lines ending in a colon as action headers before requiring an active intent, and skip other single-token lines safely. Add regression coverage for a mis-indented action following a normal action and for a mis-indented first action.
