### PR TITLE
Parse Samsung SFS logs from AndroidQF acquisitions

### DIFF
--- a/src/mvt/android/modules/androidqf/__init__.py
+++ b/src/mvt/android/modules/androidqf/__init__.py
@@ -11,6 +11,7 @@ from .aqf_processes import AQFProcesses
 from .aqf_settings import AQFSettings
 from .mounts import Mounts
 from .root_binaries import RootBinaries
+from .samsung_sfs_logs import SamsungSFSLogs
 
 ANDROIDQF_MODULES = [
     AQFPackages,
@@ -21,4 +22,5 @@ ANDROIDQF_MODULES = [
     AQFLogTimestamps,
     RootBinaries,
     Mounts,
+    SamsungSFSLogs,
 ]

--- a/src/mvt/android/modules/androidqf/samsung_sfs_logs.py
+++ b/src/mvt/android/modules/androidqf/samsung_sfs_logs.py
@@ -1,0 +1,230 @@
+# Mobile Verification Toolkit (MVT)
+# Copyright (c) 2021-2026 The MVT Authors.
+# Use of this software is governed by the MVT License 1.1 that can be found at
+#   https://license.mvt.re/1.1/
+
+import datetime
+import gzip
+import io
+import os
+import re
+from typing import IO, Optional
+
+from mvt.android.artifacts.dumpsys_adb import DumpsysADBArtifact
+from mvt.common.module_types import ModuleAtomicResult, ModuleSerializedResult
+from mvt.common.utils import convert_datetime_to_iso
+
+from .base import AndroidQFModule
+
+
+ADB_STATES = {
+    0: "unknown",
+    1: "awaiting_user_approval",
+    2: "user_allowed",
+    3: "user_denied",
+    4: "automatically_allowed",
+    5: "denied_invalid_key",
+    6: "denied_vold_decrypt",
+    7: "disconnected",
+}
+
+LOG_LINE_RE = re.compile(
+    r"^(?P<timestamp>\d{2}-\d{2}-\d{2} "
+    r"\(GMT[+-]\d{2}:\d{2}\) \d{2}:\d{2}:\d{2}\.\d{3}) "
+    r"\d+ [VDIWEAF] (?P<tag>[^:]+): (?P<message>.*)$"
+)
+ADB_KEY_RE = re.compile(
+    r"^Logging key (?P<key>.*), state = (?P<state>\d+), "
+    r"alwaysAllow = (?P<always_allow>true|false), "
+    r"lastConnectionTime = (?P<last_connection_time>\d+), "
+    r"authWindow = (?P<auth_window>\d+)$"
+)
+USB_DEVICE_RE = re.compile(
+    r"^USB device attached: vidpid (?P<vendor_id>[^:\s]+):(?P<product_id>\S+) "
+    r"mfg/product/ver(?:/serial)? "
+    r"(?P<manufacturer>.*?)/(?P<product>.*?)/(?P<version>.*?)/(?P<serial>.*?) "
+    r"hasAudio/HID/Storage: "
+    r"(?P<has_audio>true|false)/(?P<has_hid>true|false)/"
+    r"(?P<has_storage>true|false)$"
+)
+USB_UEVENT_RE = re.compile(r"^USB UEVENT: \{(?P<properties>.*)\}$")
+SFS_LOG_NAME_RE = re.compile(r"^sfslog\.\d+\.gz$", re.IGNORECASE)
+
+
+class SamsungSFSLogs(AndroidQFModule):
+    """Parse USB and ADB events from Samsung system framework logs."""
+
+    slug = "samsung_sfs_logs"
+
+    @staticmethod
+    def _parse_timestamp(value: str) -> Optional[str]:
+        try:
+            timestamp = datetime.datetime.strptime(
+                value, "%y-%m-%d (GMT%z) %H:%M:%S.%f"
+            )
+        except ValueError:
+            return None
+
+        return convert_datetime_to_iso(timestamp)
+
+    @staticmethod
+    def _parse_adb_key(timestamp: str, message: str) -> Optional[dict]:
+        match = ADB_KEY_RE.match(message)
+        if not match:
+            return None
+
+        state = int(match["state"])
+        key_info = DumpsysADBArtifact.calculate_key_info(
+            match["key"].encode("utf-8")
+        )
+        return {
+            "timestamp": timestamp,
+            "event": "adb_connection",
+            "key": key_info["key"].decode("utf-8", errors="replace"),
+            "user": key_info["user"],
+            "fingerprint": key_info["fingerprint"],
+            "state": state,
+            "state_name": ADB_STATES.get(state, "unknown"),
+            "always_allow": match["always_allow"] == "true",
+            "last_connection_time": int(match["last_connection_time"]),
+            "auth_window": int(match["auth_window"]),
+        }
+
+    @staticmethod
+    def _parse_usb_device(timestamp: str, message: str) -> Optional[dict]:
+        match = USB_DEVICE_RE.match(message)
+        if not match:
+            return None
+
+        return {
+            "timestamp": timestamp,
+            "event": "usb_device_attached",
+            "vendor_id": match["vendor_id"],
+            "product_id": match["product_id"],
+            "manufacturer": match["manufacturer"],
+            "product": match["product"],
+            "version": match["version"],
+            "serial": match["serial"],
+            "has_audio": match["has_audio"] == "true",
+            "has_hid": match["has_hid"] == "true",
+            "has_storage": match["has_storage"] == "true",
+        }
+
+    @staticmethod
+    def _parse_usb_uevent(timestamp: str, message: str) -> Optional[dict]:
+        match = USB_UEVENT_RE.match(message)
+        if not match:
+            return None
+
+        properties = {}
+        for item in match["properties"].split(","):
+            key, separator, value = item.strip().partition("=")
+            if separator:
+                properties[key] = value
+
+        if "USB_STATE" not in properties:
+            return None
+
+        return {
+            "timestamp": timestamp,
+            "event": "usb_state",
+            "usb_state": properties["USB_STATE"],
+            "subsystem": properties.get("SUBSYSTEM"),
+            "sequence_number": properties.get("SEQNUM"),
+            "action": properties.get("ACTION"),
+            "device_path": properties.get("DEVPATH"),
+        }
+
+    @classmethod
+    def parse_line(cls, line: str) -> Optional[dict]:
+        match = LOG_LINE_RE.match(line.rstrip())
+        if not match:
+            return None
+
+        timestamp = cls._parse_timestamp(match["timestamp"])
+        if not timestamp:
+            return None
+
+        if match["tag"] == "AdbDebuggingManager":
+            return cls._parse_adb_key(timestamp, match["message"])
+        if match["tag"] == "UsbHostManager":
+            return cls._parse_usb_device(timestamp, match["message"])
+        if match["tag"] == "UsbDeviceManager":
+            return cls._parse_usb_uevent(timestamp, match["message"])
+
+        return None
+
+    def _get_sfs_logs(self) -> list[str]:
+        return [
+            file_path
+            for file_path in self.files
+            if SFS_LOG_NAME_RE.match(
+                file_path.replace("\\", "/").rsplit("/", 1)[-1]
+            )
+        ]
+
+    def _open_file(self, file_path: str) -> IO[bytes]:
+        if self.archive:
+            return self.archive.open(file_path)
+        if not self.parent_path:
+            raise ValueError("parent_path is not set")
+        return open(os.path.join(self.parent_path, file_path), "rb")
+
+    def run(self) -> None:
+        sfs_logs = self._get_sfs_logs()
+        if not sfs_logs:
+            self.log.info("No Samsung sfslog files found")
+            return
+
+        for file_path in sfs_logs:
+            try:
+                with self._open_file(file_path) as compressed:
+                    with gzip.GzipFile(fileobj=compressed) as gzip_file:
+                        with io.TextIOWrapper(
+                            gzip_file, encoding="utf-8", errors="replace"
+                        ) as text_file:
+                            for line in text_file:
+                                result = self.parse_line(line)
+                                if result:
+                                    result["source_file"] = file_path.replace("\\", "/")
+                                    self.results.append(result)
+            except (EOFError, OSError) as exc:
+                self.log.warning(
+                    'Unable to read Samsung system framework log "%s": %s',
+                    file_path,
+                    exc,
+                )
+
+        self.log.info(
+            "Extracted a total of %d Samsung USB and ADB events",
+            len(self.results),
+        )
+
+    def check_indicators(self) -> None:
+        return
+
+    def serialize(
+        self, record: ModuleAtomicResult
+    ) -> ModuleSerializedResult:
+        event = record["event"]
+        if event == "adb_connection":
+            data = (
+                f"ADB key {record['fingerprint'] or '<unknown>'} "
+                f"({record['user'] or 'unknown user'}): {record['state_name']}"
+            )
+        elif event == "usb_device_attached":
+            data = (
+                f"USB device {record['vendor_id']}:{record['product_id']} attached "
+                f"({record['manufacturer']} {record['product']})"
+            )
+        else:
+            data = f"USB state changed to {record['usb_state']}"
+            if record.get("device_path"):
+                data += f" at {record['device_path']}"
+
+        return {
+            "timestamp": record["timestamp"],
+            "module": self.__class__.__name__,
+            "event": event,
+            "data": data,
+        }

--- a/tests/android_androidqf/test_samsung_sfs_logs.py
+++ b/tests/android_androidqf/test_samsung_sfs_logs.py
@@ -1,0 +1,101 @@
+# Mobile Verification Toolkit (MVT)
+# Copyright (c) 2021-2026 The MVT Authors.
+# Use of this software is governed by the MVT License 1.1 that can be found at
+#   https://license.mvt.re/1.1/
+
+import gzip
+import logging
+import zipfile
+
+from mvt.android.modules.androidqf.samsung_sfs_logs import SamsungSFSLogs
+from mvt.common.module import run_module
+
+from ..utils import list_files
+
+
+SFS_LOG = """\
+25-06-18 (GMT-03:00) 18:09:15.139 1498 D AdbDebuggingManager: Logging key QUJDRA== host@example, state = 2, alwaysAllow = true, lastConnectionTime = 0, authWindow = 604800000
+25-06-18 (GMT-03:00) 18:10:00.000 1498 D UsbHostManager: USB device attached: vidpid 18d1:4ee7 mfg/product/ver/serial Google/Pixel/1.00/ABC123 hasAudio/HID/Storage: true/false/true
+25-06-18 (GMT-03:00) 18:10:01.000 1498 V UsbDeviceManager: USB UEVENT: {SUBSYSTEM=android_usb, SEQNUM=42, ACTION=change, USB_STATE=CONFIGURED, DEVPATH=/devices/test}
+malformed line
+"""
+
+
+def test_parse_samsung_sfs_log_from_directory(tmp_path):
+    data_path = tmp_path / "androidqf"
+    log_path = data_path / "logs" / "data" / "log" / "sfslog.0.gz"
+    log_path.parent.mkdir(parents=True)
+    log_path.write_bytes(gzip.compress(SFS_LOG.encode()))
+
+    module = SamsungSFSLogs(target_path=str(data_path), log=logging)
+    module.from_dir(
+        str(data_path.parent),
+        list_files(str(data_path)),
+    )
+    run_module(module)
+
+    assert len(module.results) == 3
+    assert len(module.timeline) == 3
+
+    adb_result, device_result, state_result = module.results
+    assert adb_result == {
+        "timestamp": "2025-06-18 21:09:15.139000",
+        "event": "adb_connection",
+        "key": "QUJDRA==",
+        "user": "host@example",
+        "fingerprint": "CB:08:CA:4A:7B:B5:F9:68:3C:19:13:3A:84:87:2C:A7",
+        "state": 2,
+        "state_name": "user_allowed",
+        "always_allow": True,
+        "last_connection_time": 0,
+        "auth_window": 604800000,
+        "source_file": "androidqf/logs/data/log/sfslog.0.gz",
+    }
+    assert device_result["event"] == "usb_device_attached"
+    assert device_result["vendor_id"] == "18d1"
+    assert device_result["product_id"] == "4ee7"
+    assert device_result["serial"] == "ABC123"
+    assert device_result["has_audio"] is True
+    assert device_result["has_hid"] is False
+    assert device_result["has_storage"] is True
+    assert state_result["event"] == "usb_state"
+    assert state_result["usb_state"] == "CONFIGURED"
+    assert state_result["sequence_number"] == "42"
+    assert state_result["device_path"] == "/devices/test"
+
+
+def test_parse_samsung_sfs_log_from_zip(tmp_path):
+    archive_path = tmp_path / "androidqf.zip"
+    with zipfile.ZipFile(archive_path, "w") as archive:
+        archive.writestr(
+            "androidqf/logs/data/log/sfslog.1.gz",
+            gzip.compress(SFS_LOG.encode()),
+        )
+
+    with zipfile.ZipFile(archive_path) as archive:
+        module = SamsungSFSLogs(target_path=str(archive_path), log=logging)
+        module.from_zip(archive, archive.namelist())
+        run_module(module)
+
+    assert len(module.results) == 3
+    assert all(
+        result["source_file"] == "androidqf/logs/data/log/sfslog.1.gz"
+        for result in module.results
+    )
+
+
+def test_invalid_samsung_sfs_log_is_skipped(tmp_path, caplog):
+    data_path = tmp_path / "androidqf"
+    log_path = data_path / "logs" / "data" / "log" / "sfslog.0.gz"
+    log_path.parent.mkdir(parents=True)
+    log_path.write_text("not gzip")
+
+    module = SamsungSFSLogs(target_path=str(data_path), log=logging)
+    module.from_dir(
+        str(data_path.parent),
+        list_files(str(data_path)),
+    )
+    run_module(module)
+
+    assert module.results == []
+    assert "Unable to read Samsung system framework log" in caplog.text

--- a/tests/test_check_android_androidqf.py
+++ b/tests/test_check_android_androidqf.py
@@ -15,6 +15,7 @@ from mvt.android.cli import check_androidqf
 from mvt.android.cmd_check_androidqf import CmdAndroidCheckAndroidQF
 from mvt.android.modules.androidqf import ANDROIDQF_MODULES
 from mvt.android.modules.androidqf.aqf_log_timestamps import AQFLogTimestamps
+from mvt.android.modules.androidqf.samsung_sfs_logs import SamsungSFSLogs
 from mvt.common.config import settings
 
 from .utils import get_artifact_folder
@@ -25,6 +26,9 @@ TEST_BACKUP_PASSWORD = "123456"
 class TestCheckAndroidqfCommand:
     def test_log_timestamps_module_is_registered(self):
         assert AQFLogTimestamps in ANDROIDQF_MODULES
+
+    def test_samsung_sfs_logs_module_is_registered(self):
+        assert SamsungSFSLogs in ANDROIDQF_MODULES
 
     def test_check(self):
         runner = CliRunner()


### PR DESCRIPTION
Adds a `SamsungSFSLogs` AndroidQF module for Samsung system framework logs collected from `/data/log/sfslog.#.gz`.

The module extracts timestamped ADB key state transitions, including key fingerprints and Android state names, as well as attached USB device metadata and USB connection-state events. It normalizes each record's embedded GMT offset to UTC, emits timeline entries, supports both directory and ZIP acquisitions, and skips malformed gzip files without aborting the analysis.