### PR TITLE
Parse package installer from bugreports

### DIFF
--- a/src/mvt/android/artifacts/dumpsys_packages.py
+++ b/src/mvt/android/artifacts/dumpsys_packages.py
@@ -71,6 +71,7 @@ class DumpsysPackagesArtifact(AndroidArtifact):
             "timestamp": "",
             "first_install_time": "",
             "last_update_time": "",
+            "installer": "",
             "permissions": list(),
             "requested_permissions": list(),
         }
@@ -126,6 +127,8 @@ class DumpsysPackagesArtifact(AndroidArtifact):
                 details["version_code"] = line.split("=", 1)[1].strip()
             elif line.strip().startswith("timeStamp="):
                 details["timestamp"] = line.split("=")[1].strip()
+            elif line.strip().startswith("installerPackageName="):
+                details["installer"] = line.split("=", 1)[1].strip()
             elif line.strip().startswith("firstInstallTime="):
                 details["first_install_time"] = line.split("=")[1].strip()
             elif line.strip().startswith("lastUpdateTime="):

--- a/tests/android_bugreport/test_bugreport.py
+++ b/tests/android_bugreport/test_bugreport.py
@@ -54,6 +54,8 @@ class TestBugreportAnalysis:
             == "com.samsung.android.provider.filterprovider"
         )
         assert m.results[1]["package_name"] == "com.instagram.android"
+        assert m.results[0]["installer"] == ""
+        assert m.results[1]["installer"] == "com.android.vending"
         assert len(m.results[0]["permissions"]) == 4
         assert len(m.results[1]["permissions"]) == 32
 


### PR DESCRIPTION
## Summary

- Parse `installerPackageName` from dumpsys package entries.
- Include a stable `installer` field when no installer is reported.
- Add regression coverage for populated and missing installer metadata.

## Rationale

Bugreport package analysis previously discarded installer provenance even when Android included it in `dumpsys package` output. Preserving this value makes installation-source information available in exported package results.

Fixes #867
