### PR TITLE
Parse system package flags from bugreports

### DIFF
--- a/src/mvt/android/artifacts/dumpsys_packages.py
+++ b/src/mvt/android/artifacts/dumpsys_packages.py
@@ -72,6 +72,7 @@ class DumpsysPackagesArtifact(AndroidArtifact):
             "first_install_time": "",
             "last_update_time": "",
             "installer": "",
+            "system": False,
             "permissions": list(),
             "requested_permissions": list(),
         }
@@ -136,6 +137,8 @@ class DumpsysPackagesArtifact(AndroidArtifact):
                 details["timestamp"] = line.split("=")[1].strip()
             elif line.strip().startswith("installerPackageName="):
                 details["installer"] = line.split("=", 1)[1].strip()
+            elif line.strip().startswith("pkgFlags="):
+                details["system"] = "SYSTEM" in line.split("=", 1)[1].split()
             elif line.strip().startswith("firstInstallTime="):
                 first_install_times[current_user] = line.split("=", 1)[1].strip()
             elif line.strip().startswith("lastUpdateTime="):

--- a/tests/android/test_artifact_dumpsys_packages.py
+++ b/tests/android/test_artifact_dumpsys_packages.py
@@ -26,6 +26,24 @@ class TestDumpsysPackagesArtifact:
         )
         assert dpa.results[0]["version_name"] == "5.0.07"
         assert dpa.results[0]["first_install_time"] == "2008-12-31 16:00:00"
+        assert dpa.results[0]["system"] is True
+
+    def test_parsing_system_flag(self):
+        system_details = DumpsysPackagesArtifact.parse_dumpsys_package_for_details(
+            "    pkgFlags=[ SYSTEM HAS_CODE ALLOW_CLEAR_USER_DATA ]"
+        )
+        third_party_details = DumpsysPackagesArtifact.parse_dumpsys_package_for_details(
+            "    pkgFlags=[ HAS_CODE ALLOW_BACKUP ]"
+        )
+        missing_flag_details = (
+            DumpsysPackagesArtifact.parse_dumpsys_package_for_details(
+                "    versionName=1.0"
+            )
+        )
+
+        assert system_details["system"] is True
+        assert third_party_details["system"] is False
+        assert missing_flag_details["system"] is False
 
     def test_ioc_check(self, indicator_file):
         dpa = DumpsysPackagesArtifact()


### PR DESCRIPTION
## Summary

Parse the `SYSTEM` token from `dumpsys package` `pkgFlags` lines into a boolean `system` field. Package records default to `false` when the token or flag line is absent, aligning bugreport output with the AndroidQF package data model.

Closes #873