### PR TITLE
Document iOS device access from Docker

### DIFF
--- a/docs/docker.md
+++ b/docs/docker.md
@@ -45,4 +45,4 @@ docker run -it \
     ghcr.io/mvt-project/mvt
 ```
 
-If you built the image from source, replace `ghcr.io/mvt-project/mvt` with `mvt`. You do not need to mount the entire `/var/run` directory.
+If you built the image from source, replace `ghcr.io/mvt-project/mvt` with `mvt`. 

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -32,3 +32,17 @@ docker run -it mvt
 ```
 
 If a prompt is spawned successfully, you can close it with `exit`.
+
+## Access an iOS device from Docker
+
+On the Linux host, install and start [usbmuxd](https://github.com/libimobiledevice/usbmuxd), then connect and unlock the iOS device. The daemon exposes the device through the `/var/run/usbmuxd` socket.
+
+Bind that socket into the container to let MVT communicate with the device:
+
+```bash
+docker run -it \
+    --mount type=bind,source=/var/run/usbmuxd,target=/var/run/usbmuxd \
+    ghcr.io/mvt-project/mvt
+```
+
+If you built the image from source, replace `ghcr.io/mvt-project/mvt` with `mvt`. You do not need to mount the entire `/var/run` directory.


### PR DESCRIPTION
Document how Linux users can expose the host usbmuxd socket to the MVT Docker container so it can communicate with a connected iOS device.

The guide uses a targeted bind mount for /var/run/usbmuxd and explicitly avoids mounting the entire /var/run directory. It also covers both the prebuilt image and an image built from source.

Closes #524.

The strict MkDocs build and git diff check pass.