### PR TITLE
Add Android bugreport output schema version

### DIFF
--- a/src/mvt/android/cmd_check_bugreport.py
+++ b/src/mvt/android/cmd_check_bugreport.py
@@ -53,6 +53,7 @@ class CmdAndroidCheckBugreport(Command):
 
         self.platform = "android"
         self.name = "check-bugreport"
+        self.output_schema_version = 2
         self.modules = BUGREPORT_MODULES
 
         self.__format: str = ""

--- a/src/mvt/common/command.py
+++ b/src/mvt/common/command.py
@@ -54,6 +54,7 @@ class Command:
     ) -> None:
         self.name = ""
         self.platform = ""
+        self.output_schema_version: Optional[int] = None
         self.modules: list[type[MVTModule]] = []
         self.custom_modules = custom_modules if custom_modules else []
 
@@ -186,6 +187,8 @@ class Command:
             "ioc_files": [],
             "hashes": [],
         }
+        if self.output_schema_version is not None:
+            info["output_schema_version"] = self.output_schema_version
 
         for coll in self.iocs.ioc_collections:
             ioc_file_path = coll.get("stix2_file_path", "")


### PR DESCRIPTION
## Summary

- add optional output schema metadata to the shared command information
- identify the normalized Android bugreport result contract as schema version 2

## Why

The parser PR intentionally changes several result shapes and field types. Consumers need a machine-readable way to distinguish those results from the previous contract.

This is a stacked PR on top of #871 so schema version 2 cannot be merged independently of the breaking parser changes it describes.

## Behavior

Commands without an explicit schema version keep their existing metadata unchanged. Android bugreport analysis sets `output_schema_version` to `2`, which is then included in the generated command information.