### PR TITLE
Fix getprop parsing of multi-line property values

### DIFF
--- a/src/mvt/android/artifacts/getprop.py
+++ b/src/mvt/android/artifacts/getprop.py
@@ -28,19 +28,16 @@ INTERESTING_PROPERTIES = [
 class GetProp(AndroidArtifact):
     def parse(self, entry: str) -> None:
         self.results: List[Dict[str, str]] = []
-        rxp = re.compile(r"\[(.+?)\]: \[(.+?)\]")
+        # A property value may span several lines: persist.sys.boot.reason.history
+        # prints one boot per line. Matching the whole section instead of line by
+        # line lets the value run to the first closing bracket that ends a line.
+        rxp = re.compile(
+            r"^[ \t]*\[([^\]\n]+)\]: \[(.*?)\][ \t\r]*$",
+            re.MULTILINE | re.DOTALL,
+        )
 
-        for line in entry.splitlines():
-            line = line.strip()
-            if line == "":
-                continue
-
-            matches = re.findall(rxp, line)
-            if not matches or len(matches[0]) != 2:
-                continue
-
-            prop_entry = {"name": matches[0][0], "value": matches[0][1]}
-            self.results.append(prop_entry)
+        for name, value in rxp.findall(entry):
+            self.results.append({"name": name, "value": value})
 
     def get_device_timezone(self) -> str | None:
         """

--- a/tests/android/test_artifact_getprop.py
+++ b/tests/android/test_artifact_getprop.py
@@ -19,9 +19,24 @@ class TestGetPropArtifact:
 
         assert len(gp.results) == 0
         gp.parse(data)
-        assert len(gp.results) == 13
+        assert len(gp.results) == 14
         assert gp.results[0]["name"] == "af.fast_track_multiplier"
         assert gp.results[0]["value"] == "1"
+
+    def test_parsing_multiline_value(self):
+        gp = GetProp()
+        file = get_artifact("android_data/getprop.txt")
+        with open(file) as f:
+            data = f.read()
+
+        gp.parse(data)
+        properties = {entry["name"]: entry["value"] for entry in gp.results}
+
+        assert properties["persist.sys.boot.reason.history"] == (
+            "reboot,userrequested,mainline_update,1782907395\n"
+            "reboot,userrequested,1782582256\n"
+            "shutdown,userrequested,1781742871"
+        )
 
     def test_ioc_check(self, indicator_file):
         gp = GetProp()

--- a/tests/artifacts/android_data/getprop.txt
+++ b/tests/artifacts/android_data/getprop.txt
@@ -12,3 +12,6 @@
 [dalvik.vm.dex2oat-resolve-startup-strings]: [true]
 [dalvik.vm.dexopt.secondary]: [true]
 [dalvik.vm.heapgrowthlimit]: [192m]
+[persist.sys.boot.reason.history]: [reboot,userrequested,mainline_update,1782907395
+reboot,userrequested,1782582256
+shutdown,userrequested,1781742871]


### PR DESCRIPTION
`GetProp.parse()` matches `[name]: [value]` line by line, so a value containing newlines never matches and the property is dropped — with no log line, only the usual "Extracted N Android system properties". `persist.sys.boot.reason.history` is multi-line by construction (one boot per line), so it is missing on nearly every device. It is the device's own record of why it restarted, with an epoch timestamp per event (`reboot,userrequested`, `reboot,ota`, `recovery`, `shutdown,battery`, `kernel_panic`, `watchdog`).

Raw:

```
[persist.sys.boot.reason.history]: [reboot,userrequested,mainline_update,1782907395
reboot,userrequested,1782582256
shutdown,userrequested,1781742871]
```

Fix: match the whole section once, with the value closed by the first `]` that ends a line.

```python
rxp = re.compile(r"^[ \t]*\[([^\]\n]+)\]: \[(.*?)\][ \t\r]*$", re.MULTILINE | re.DOTALL)
```

The value stays one newline-joined string, so the record shape `{"name", "value"}` is unchanged for consumers. Happy to switch to a list if you prefer.

**Relation to #871.** #871 already rewrites this regex as `^\[([^]]+)\]: \[(.*)\]$`, which fixes the empty-value (`[name]: []`) and bracket-in-value cases on its own — those are its fixes, not this PR's, and this PR is deliberately narrowed to the multi-line case, which a line-by-line match cannot capture. Marked as a draft so it does not compete for review or add a conflict to #871: after #871 lands I will rebase this onto it, keeping its `[^]]+` name group. The same suggestion is posted inline on #871 if you would rather fold it in there and close this.

Checked in the worktree: `ruff check`, `mypy`, `pytest tests` all pass; new `test_parsing_multiline_value` with a three-line property in the shared `getprop.txt` fixture (count assertion 13 → 14).
