### PR TITLE
Do not end the whole androidqf run on an encrypted backup.ab

### DIFF
--- a/src/mvt/android/cmd_check_androidqf.py
+++ b/src/mvt/android/cmd_check_androidqf.py
@@ -292,9 +292,7 @@ class CmdAndroidCheckAndroidQF(Command):
         try:
             cmd.from_ab(backup)
         except InvalidAndroidBackup as exc:
-            self.log.warning(
-                "Skipping backup modules as backup.ab is malformed: %s", exc
-            )
+            self.log.warning("Skipping backup modules: %s", exc)
             return False
 
         cmd.run()

--- a/src/mvt/android/cmd_check_backup.py
+++ b/src/mvt/android/cmd_check_backup.py
@@ -87,11 +87,15 @@ class CmdAndroidCheckBackup(Command):
         if header["encryption"] != "none":
             password = prompt_or_load_android_backup_password(log, self.module_options)
             if not password:
+                if self.sub_command:
+                    raise InvalidAndroidBackup("No backup password provided")
                 log.critical("No backup password provided.")
                 sys.exit(1)
         try:
             tardata = parse_backup_file(ab_file_bytes, password=password)
         except InvalidBackupPassword:
+            if self.sub_command:
+                raise InvalidAndroidBackup("Invalid backup password")
             log.critical("Invalid backup password")
             sys.exit(1)
         except AndroidBackupParsingError as exc:

--- a/tests/android/test_check_backup_optional_failure.py
+++ b/tests/android/test_check_backup_optional_failure.py
@@ -1,0 +1,39 @@
+# Mobile Verification Toolkit (MVT)
+# Copyright (c) 2021-2023 The MVT Authors.
+# Use of this software is governed by the MVT License 1.1 that can be found at
+#   https://license.mvt.re/1.1/
+"""An encrypted backup.ab must not take the whole check-androidqf run with it.
+
+`CmdAndroidCheckBackup.from_ab()` already raises `InvalidAndroidBackup` instead
+of exiting when it runs as a sub-command (`check-androidqf` catches that and
+skips the backup modules), for a wrong file format and for a parse error. The
+password branches used to call `sys.exit(1)` unconditionally, which ends the
+parent run inside `finish()` — before the intrusion-logs command and before the
+timeline, alerts, urls, info and run-manifest are written.
+"""
+
+import pytest
+
+from mvt.android.cmd_check_backup import CmdAndroidCheckBackup, InvalidAndroidBackup
+
+ENCRYPTED_AB_HEADER = b"ANDROID BACKUP\n5\n0\nAES-256\n" + b"\x00" * 64
+
+
+class TestCheckBackupOptionalFailure:
+    def _cmd(self, tmp_path, sub_command):
+        return CmdAndroidCheckBackup(
+            target_path=None,
+            results_path=str(tmp_path),
+            module_options={"interactive": False},
+            sub_command=sub_command,
+        )
+
+    def test_missing_password_raises_when_nested(self, tmp_path):
+        cmd = self._cmd(tmp_path, sub_command=True)
+        with pytest.raises(InvalidAndroidBackup):
+            cmd.from_ab(ENCRYPTED_AB_HEADER)
+
+    def test_missing_password_still_exits_on_its_own_command(self, tmp_path):
+        cmd = self._cmd(tmp_path, sub_command=False)
+        with pytest.raises(SystemExit):
+            cmd.from_ab(ENCRYPTED_AB_HEADER)

--- a/tests/test_check_android_androidqf.py
+++ b/tests/test_check_android_androidqf.py
@@ -155,7 +155,7 @@ class TestCheckAndroidqfCommand:
             result = runner.invoke(check_androidqf, [str(path)])
 
         assert result.exit_code == 0
-        assert "Skipping backup modules as backup.ab is malformed" in caplog.text
+        assert "Skipping backup modules: Invalid backup format" in caplog.text
         assert not any(
             record.levelname in {"CRITICAL", "FATAL"} for record in caplog.records
         )


### PR DESCRIPTION
## Summary

`CmdAndroidCheckBackup.from_ab()` raises `InvalidAndroidBackup` instead of exiting when it runs as a sub-command — #824 added that for the wrong-file-format, parse-error and tar-error branches, and `check-androidqf`'s `run_backup_cmd()` catches it and skips the backup modules. The two password branches were left calling `sys.exit(1)` unconditionally, so an **encrypted `backup.ab` whose password is not supplied ends the entire `check-androidqf` run**.

That is more than the backup modules. `run_backup_cmd()` is called from `finish()`, so the exit happens before:

- `run_intrusion_logs_cmd()` — the Intrusion Logging channel never runs;
- `_store_timeline()`, `_store_alerts_timeline()`, `_store_alerts()`, `_store_urls()`, `_store_info()`, `_store_run_manifest()` in `Command.run()`.

The per-module JSONs are already on disk by then, so the output directory looks like a finished run while `alerts.json` — MVT's own detection summary — is simply not there.

Measured on an AndroidQF acquisition with a synthetic AES-256 `backup.ab` header, `check-androidqf -n`:

| | before | after |
|---|---|---|
| `alerts.json`, `alerts_timeline.csv`, `timeline.csv`, `info.json` | absent | written |
| Intrusion Logging command | never runs | runs |
| exit code | 1 | 0 |

After the change the output directory matches, file for file, a control run of the same acquisition without a `backup.ab`.

## Changes

- `cmd_check_backup.py`: both password branches raise `InvalidAndroidBackup` when `self.sub_command`, matching the three branches beside them. Standalone `mvt-android check-backup` still logs CRITICAL and exits 1 — unchanged.
- `cmd_check_androidqf.py`: the skip warning no longer says the backup is malformed. It covers a missing password and a wrong password too, and neither means malformed. Existing assertion in `tests/test_check_android_androidqf.py` updated to the new text.
- `tests/android/test_check_backup_optional_failure.py`: nested (`sub_command=True`) raises, standalone still exits — the second half matters, since the CLI behaviour must not change.

`uv run ruff check .`, `uv run mypy`, `uv run pytest tests` all pass (256 passed, 1 skipped).

## One thing left alone

`prompt_or_load_android_backup_password()` still logs `CRITICAL Cannot decrypt backup because interactivity was disabled and the password was not supplied` before the skip. For a nested run that is now an optional module being skipped rather than a fatal condition, but the helper has no way to know which context it is in, and the standalone command genuinely is fatal there. Happy to plumb that through if you want the level lowered when nested.
