### PR TITLE
Share the check-iocs module lists between the CLI and the code

### DIFF
--- a/src/mvt/android/cli.py
+++ b/src/mvt/android/cli.py
@@ -49,11 +49,8 @@ from .cmd_check_androidqf import CmdAndroidCheckAndroidQF
 from .cmd_check_backup import CmdAndroidCheckBackup
 from .cmd_check_bugreport import CmdAndroidCheckBugreport
 from .cmd_check_intrusion_logs import CmdAndroidCheckIntrusionLogs
-from .modules.intrusion_logs import INTRUSION_LOGS_MODULES
-from .modules.androidqf import ANDROIDQF_MODULES
-from .modules.backup import BACKUP_MODULES
+from .command_modules import ANDROID_CHECK_IOCS_MODULES
 from .modules.backup.helpers import cli_load_android_backup_password
-from .modules.bugreport import BUGREPORT_MODULES
 
 init_logging()
 log = logging.getLogger("mvt")
@@ -459,9 +456,7 @@ def check_iocs(ctx, iocs, list_modules, module, load_module, folder):
         custom_modules=custom_modules,
         platform="android",
     )
-    cmd.modules = (
-        BACKUP_MODULES + BUGREPORT_MODULES + ANDROIDQF_MODULES + INTRUSION_LOGS_MODULES
-    )
+    cmd.modules = ANDROID_CHECK_IOCS_MODULES
 
     if list_modules:
         cmd.list_modules()

--- a/src/mvt/android/command_modules.py
+++ b/src/mvt/android/command_modules.py
@@ -1,0 +1,23 @@
+# Mobile Verification Toolkit (MVT)
+# Copyright (c) 2021-2026 The MVT Authors.
+# Use of this software is governed by the MVT License 1.1 that can be found at
+#   https://license.mvt.re/1.1/
+
+"""Module lists an mvt-android command composes from more than one family.
+
+Commands whose modules are one family read that family directly. check-iocs
+re-checks stored results, so it has to know every module that could have
+written one, and both the CLI and any other code needing that answer share
+the list from here rather than each concatenating their own.
+"""
+
+from mvt.common.module import MVTModule
+
+from .modules.androidqf import ANDROIDQF_MODULES
+from .modules.backup import BACKUP_MODULES
+from .modules.bugreport import BUGREPORT_MODULES
+from .modules.intrusion_logs import INTRUSION_LOGS_MODULES
+
+ANDROID_CHECK_IOCS_MODULES: list[type[MVTModule]] = (
+    BACKUP_MODULES + BUGREPORT_MODULES + ANDROIDQF_MODULES + INTRUSION_LOGS_MODULES
+)

--- a/src/mvt/ios/cli.py
+++ b/src/mvt/ios/cli.py
@@ -53,9 +53,7 @@ from .cmd_check_backup import CmdIOSCheckBackup
 from .cmd_check_fs import CmdIOSCheckFS
 from .cmd_check_sysdiagnose import CmdIOSCheckSysdiagnose
 from .decrypt import DecryptBackup
-from .modules.backup import BACKUP_MODULES
-from .modules.fs import FS_MODULES
-from .modules.mixed import MIXED_MODULES
+from .command_modules import IOS_CHECK_IOCS_MODULES
 
 init_logging()
 log = logging.getLogger("mvt")
@@ -479,7 +477,7 @@ def check_iocs(ctx, iocs, list_modules, module, load_module, folder):
         custom_modules=custom_modules,
         platform="ios",
     )
-    cmd.modules = BACKUP_MODULES + FS_MODULES + MIXED_MODULES
+    cmd.modules = IOS_CHECK_IOCS_MODULES
 
     if list_modules:
         cmd.list_modules()

--- a/src/mvt/ios/command_modules.py
+++ b/src/mvt/ios/command_modules.py
@@ -1,0 +1,22 @@
+# Mobile Verification Toolkit (MVT)
+# Copyright (c) 2021-2026 The MVT Authors.
+# Use of this software is governed by the MVT License 1.1 that can be found at
+#   https://license.mvt.re/1.1/
+
+"""Module lists an mvt-ios command composes from more than one family.
+
+Commands whose modules are one family read that family directly. check-iocs
+re-checks stored results, so it has to know every module that could have
+written one, and both the CLI and any other code needing that answer share
+the list from here rather than each concatenating their own.
+"""
+
+from mvt.common.module import MVTModule
+
+from .modules.backup import BACKUP_MODULES
+from .modules.fs import FS_MODULES
+from .modules.mixed import MIXED_MODULES
+
+IOS_CHECK_IOCS_MODULES: list[type[MVTModule]] = (
+    BACKUP_MODULES + FS_MODULES + MIXED_MODULES
+)

--- a/tests/common/test_cmd_check_iocs.py
+++ b/tests/common/test_cmd_check_iocs.py
@@ -1,0 +1,139 @@
+# Mobile Verification Toolkit (MVT)
+# Copyright (c) 2021-2026 The MVT Authors.
+# Use of this software is governed by the MVT License 1.1 that can be found at
+#   https://license.mvt.re/1.1/
+
+import json
+import logging
+
+import pytest
+from click.testing import CliRunner
+
+from mvt.android.cli import cli as android_cli
+from mvt.android.command_modules import ANDROID_CHECK_IOCS_MODULES
+from mvt.common.cmd_check_iocs import CmdCheckIOCS
+from mvt.common.module import MVTModule
+from mvt.ios.cli import cli as ios_cli
+from mvt.ios.command_modules import IOS_CHECK_IOCS_MODULES
+
+# Keep the banner of the group callback from checking for updates online.
+OFFLINE = ["--disable-update-check", "--disable-indicator-update-check"]
+
+
+class CustomResultsModule(MVTModule):
+    """A custom module which declares the check-iocs pair of both platforms."""
+
+    slug = "custom_results"
+    supported_commands = (
+        ("ios", "check-backup"),
+        ("ios", "check-iocs"),
+        ("android", "check-iocs"),
+    )
+
+    checked: list = []
+
+    def run(self) -> None:
+        pass
+
+    def check_indicators(self) -> None:
+        self.checked.append(list(self.results))
+
+
+class BackupOnlyModule(MVTModule):
+    """A custom module which does not declare check-iocs."""
+
+    slug = "backup_only"
+    supported_commands = (("ios", "check-backup"),)
+
+    def check_indicators(self) -> None:
+        raise AssertionError("must not be re-checked")
+
+
+@pytest.mark.parametrize(
+    "platform, builtin_modules",
+    [("ios", IOS_CHECK_IOCS_MODULES), ("android", ANDROID_CHECK_IOCS_MODULES)],
+)
+def test_check_iocs_rechecks_the_stored_results_of_custom_modules(
+    platform, builtin_modules, tmp_path, caplog
+):
+    # check-iocs matches every <slug>.json in the results folder to the module
+    # with that slug, custom modules included, and runs its check_indicators()
+    # again over the stored results.
+    results = [{"domain": "example.org"}]
+    (tmp_path / "custom_results.json").write_text(json.dumps(results))
+    (tmp_path / "backup_only.json").write_text(json.dumps(results))
+    CustomResultsModule.checked.clear()
+
+    cmd = CmdCheckIOCS(
+        target_path=str(tmp_path),
+        custom_modules=[CustomResultsModule, BackupOnlyModule],
+        platform=platform,
+    )
+    cmd.modules = builtin_modules
+
+    with caplog.at_level(logging.INFO):
+        cmd.run()
+
+    assert CustomResultsModule.checked == [results]
+    assert (
+        'Loading results from "custom_results.json" with module CustomResultsModule'
+        in caplog.text
+    )
+    # A module declaring only check-backup is not part of check-iocs.
+    assert "backup_only.json" not in caplog.text
+
+
+def test_check_iocs_lists_custom_modules_declaring_the_command(caplog):
+    cmd = CmdCheckIOCS(
+        custom_modules=[CustomResultsModule, BackupOnlyModule],
+        platform="ios",
+    )
+    cmd.modules = IOS_CHECK_IOCS_MODULES
+
+    with caplog.at_level(logging.INFO):
+        cmd.list_modules()
+
+    assert "CustomResultsModule" in caplog.text
+    assert "BackupOnlyModule" not in caplog.text
+
+
+LOADED_MODULE = '''
+from mvt.common.module import MVTModule
+
+
+class LoadedResultsModule(MVTModule):
+    """A module loaded from a file with --load-module."""
+
+    slug = "loaded_results"
+    supported_commands = (("ios", "check-iocs"), ("android", "check-iocs"))
+
+    def run(self) -> None:
+        pass
+
+    def check_indicators(self) -> None:
+        self.log.warning("loaded module checked %d results", len(self.results))
+'''
+
+
+@pytest.mark.parametrize("cli", [ios_cli, android_cli], ids=["mvt-ios", "mvt-android"])
+def test_check_iocs_loads_custom_modules_from_a_file_on_each_cli(cli, tmp_path, caplog):
+    module_path = tmp_path / "loaded_module.py"
+    module_path.write_text(LOADED_MODULE)
+    results_folder = tmp_path / "results"
+    results_folder.mkdir()
+    (results_folder / "loaded_results.json").write_text(json.dumps([{"a": 1}]))
+
+    with caplog.at_level(logging.INFO):
+        result = CliRunner().invoke(
+            cli,
+            [
+                *OFFLINE,
+                "check-iocs",
+                "--load-module",
+                str(module_path),
+                str(results_folder),
+            ],
+        )
+
+    assert result.exit_code == 0, result.output
+    assert "loaded module checked 1 results" in caplog.text

--- a/tests/common/test_command_modules.py
+++ b/tests/common/test_command_modules.py
@@ -1,0 +1,27 @@
+# Mobile Verification Toolkit (MVT)
+# Copyright (c) 2021-2026 The MVT Authors.
+# Use of this software is governed by the MVT License 1.1 that can be found at
+#   https://license.mvt.re/1.1/
+
+from mvt.android.command_modules import ANDROID_CHECK_IOCS_MODULES
+from mvt.android.modules.androidqf import ANDROIDQF_MODULES
+from mvt.android.modules.backup import BACKUP_MODULES as ANDROID_BACKUP_MODULES
+from mvt.android.modules.bugreport import BUGREPORT_MODULES
+from mvt.android.modules.intrusion_logs import INTRUSION_LOGS_MODULES
+from mvt.ios.command_modules import IOS_CHECK_IOCS_MODULES
+from mvt.ios.modules.backup import BACKUP_MODULES as IOS_BACKUP_MODULES
+from mvt.ios.modules.fs import FS_MODULES
+from mvt.ios.modules.mixed import MIXED_MODULES
+
+
+def test_the_check_iocs_lists_are_the_families_of_their_platform():
+    # The CLI reads these same lists, so nothing composing one elsewhere can
+    # drift from what the command runs. This pins what the lists are composed
+    # of.
+    assert IOS_CHECK_IOCS_MODULES == IOS_BACKUP_MODULES + FS_MODULES + MIXED_MODULES
+    assert ANDROID_CHECK_IOCS_MODULES == (
+        ANDROID_BACKUP_MODULES
+        + BUGREPORT_MODULES
+        + ANDROIDQF_MODULES
+        + INTRUSION_LOGS_MODULES
+    )


### PR DESCRIPTION
check-iocs re-checks the results a previous run stored, so its module list is every module of the platform that could have written one. Each platform's CLI composed that list inline, concatenating the families by hand, so the list existed only inside the click callback: anything else needing to know what check-iocs runs had to build its own copy, and the two could drift apart without a test noticing.

Give each platform a command_modules.py holding the one list, and have its CLI assign it. The modules check-iocs runs are unchanged, and a test pins each list to the families it is composed of.

**Custom modules are re-checked too.** check-iocs takes its custom modules from the same `load_custom_modules()` as the other `check-*` commands — installed plugin packages, `MVT_CUSTOM_MODULES` and `--load-module` — keeps the ones whose `supported_commands` include the `check-iocs` pair of the platform, and matches every `<slug>.json` in the results folder to the module with that slug before running its `check_indicators()` again. Nothing asserted that, so a test now pins it on both platforms, through the command class and through `--load-module` on both CLIs. A module which declares only `check-backup` is not re-checked; the plugin docs (#901) say so under the list of supported pairs.

---

Part 8 of the plugin-system series (stacked on #899, `feature/plugin-verbose-logging`).
