### PR TITLE
Release monthly from a scheduled workflow

### DIFF
--- a/.github/workflows/publish-release-docker.yml
+++ b/.github/workflows/publish-release-docker.yml
@@ -37,6 +37,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7
+        with:
+          fetch-depth: 0 # the package version comes from the git tags
       # Uses the `docker/login-action` action to log in to the Container registry registry using the account and password that will publish the packages. Once published, the packages are scoped to the account defined here.
       - name: Log in to the Container registry
         uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,44 @@
+name: Release
+
+on:
+  schedule:
+    - cron: "0 9 1 * *" # first of the month
+  workflow_dispatch:
+  push:
+    tags: ["v*"]
+
+jobs:
+  tag:
+    if: github.ref_type != 'tag'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      actions: write
+    env:
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+      - run: |
+          last=$(git describe --tags --abbrev=0 --match 'v*')
+          if [ "$(git rev-list "$last..HEAD" --count)" = 0 ]; then
+            echo "Nothing merged since $last"; exit 0
+          fi
+          tag=v$(date -u +%Y.%-m.%-d)
+          gh release create "$tag" --target "$GITHUB_SHA" --generate-notes
+          # Events made with GITHUB_TOKEN don't start other workflows; run them by hand.
+          gh workflow run release.yml --ref "$tag"
+          gh workflow run publish-release-docker.yml --ref "$tag"
+
+  publish:
+    if: github.ref_type == 'tag'
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write # PyPI trusted publishing
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+      - uses: astral-sh/setup-uv@v10.0.0
+      - run: uv build && uv publish

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,7 @@ name: Release
 
 on:
   schedule:
-    - cron: "0 9 1 * *" # first of the month
+    - cron: "0 9 * * 1" # Mondays, 09:00 UTC
   workflow_dispatch:
   push:
     tags: ["v*"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -122,6 +122,7 @@ RUN apt-get update \
   binutils \
   default-jre-headless \
   file \
+  git \
   jq \
   less \
   libcurl4 \

--- a/Makefile
+++ b/Makefile
@@ -32,8 +32,3 @@ clean:
 dist:
 	$(UV) build
 
-upload:
-	$(UV) tool run twine upload dist/*
-
-test-upload:
-	$(UV) tool run twine upload --repository testpypi dist/*

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,7 +72,7 @@ docs = [
 ]
 
 [build-system]
-requires = ["setuptools>=61.0"]
+requires = ["setuptools>=61.0", "setuptools-scm>=8"]
 build-backend = "setuptools.build_meta"
 
 [tool.coverage.run]
@@ -121,5 +121,6 @@ where = ["src"]
 [tool.setuptools.package-data]
 mvt = ["ios/data/*.json"]
 
-[tool.setuptools.dynamic]
-version = { attr = "mvt.common.version.MVT_VERSION" }
+[tool.setuptools_scm]
+# The version is the latest v* tag; ignore the archive/* tags.
+git_describe_command = "git describe --dirty --tags --long --match 'v*'"

--- a/src/mvt/common/version.py
+++ b/src/mvt/common/version.py
@@ -3,4 +3,6 @@
 # Use of this software is governed by the MVT License 1.1 that can be found at
 #   https://license.mvt.re/1.1/
 
-MVT_VERSION = "2026.7.29"
+from importlib.metadata import version
+
+MVT_VERSION = version("mvt")


### PR DESCRIPTION
The package version now comes from the latest v* git tag, so a release is a tag and nothing else. A scheduled workflow tags main on the first of the month when something was merged since the last release, creates the GitHub release with generated notes, and publishes to PyPI and the container registry. Pushing a v* tag by hand goes through the same path.