### PR TITLE
Do not keep the settings row's own metadata inside the value

### DIFF
--- a/src/mvt/android/artifacts/settings.py
+++ b/src/mvt/android/artifacts/settings.py
@@ -7,6 +7,15 @@ import re
 
 from .artifact import AndroidArtifact
 
+# The row's own metadata follows the value ("value:1 default:1
+# defaultSystemSet:true isValuePreservedInRestore:true"). It starts at the
+# FIRST of these keys, not the last: a metadata value can itself contain
+# spaces ("value:Galaxy Z Flip6 default:Galaxy Z Flip6 ...").
+TRAILING_META_RXP = re.compile(
+    r"\s+(?:default|defaultSystemSet|tag|isValuePreservedInRestore):"
+    r"|\s+(?:not)?[Pp]reservedInRestore\b"
+)
+
 ANDROID_DANGEROUS_SETTINGS = [
     {
         "description": "disabled Google Play Services apps verification",
@@ -77,12 +86,15 @@ class Settings(AndroidArtifact):
             if namespace is None or not line.startswith("_id:"):
                 continue
             setting = re.match(
-                r"^_id:\S+\s+name:(.*?)\s+pkg:.*?\s+value:(.*?)"
-                r"(?:\s+default:.*\s+defaultSystemSet:(?:true|false))?$",
+                r"^_id:\S+\s+name:(.*?)\s+pkg:.*?\s+value:(.*)$",
                 line,
             )
             if setting:
-                self.results[namespace][setting.group(1)] = setting.group(2)
+                # Metadata left inside the value is compared to `safe_value`
+                # literally by check_indicators(), which flags safe settings.
+                self.results[namespace][setting.group(1)] = TRAILING_META_RXP.split(
+                    setting.group(2)
+                )[0].strip()
 
     def check_indicators(self) -> None:
         for namespace, settings in self.results.items():

--- a/tests/android/test_artifact_settings_metadata.py
+++ b/tests/android/test_artifact_settings_metadata.py
@@ -1,0 +1,76 @@
+# Mobile Verification Toolkit (MVT)
+# Copyright (c) 2021-2023 The MVT Authors.
+# Use of this software is governed by the MVT License 1.1 that can be found at
+#   https://license.mvt.re/1.1/
+"""The row's metadata is not part of the value.
+
+`dumpsys settings` prints per-row metadata after the value. Keeping it inside
+the value makes `check_indicators()` compare `"1 isValuePreservedInRestore:true"`
+against a `safe_value` of `"1"` — so a setting that is in fact SAFE is reported
+as suspicious. Local patch 0025.
+"""
+
+from mvt.android.artifacts.settings import Settings
+
+HEADER = "GLOBAL SETTINGS (user 0)\n"
+
+
+def _parse(rows):
+    artifact = Settings()
+    artifact.results = {}
+    artifact.parse(HEADER + rows)
+    return artifact.results["global:user_0"]
+
+
+class TestSettingsValueIsStrippedOfRowMetadata:
+    def test_metadata_after_default_system_set_is_dropped(self):
+        # The shape the old inline regex missed: it anchored
+        # `defaultSystemSet:(true|false)` to end of line.
+        row = (
+            "_id:36 name:lock_screen_show_notifications pkg:android value:1 "
+            "default:1 defaultSystemSet:true isValuePreservedInRestore:true\n"
+        )
+        assert _parse(row)["lock_screen_show_notifications"] == "1"
+
+    def test_restore_flag_without_a_default_is_dropped(self):
+        rows = (
+            "_id:5 name:quick_start_flow_type pkg:android value:4 "
+            "notPreservedInRestore\n"
+            "_id:9 name:send_action_app_error pkg:android value:1 "
+            "isValuePreservedInRestore:true\n"
+        )
+        parsed = _parse(rows)
+        assert parsed["quick_start_flow_type"] == "4"
+        assert parsed["send_action_app_error"] == "1"
+
+    def test_the_shape_that_already_worked_still_works(self):
+        row = (
+            "_id:12 name:adb_enabled pkg:com.android.shell value:0 "
+            "default:0 defaultSystemSet:true\n"
+        )
+        assert _parse(row)["adb_enabled"] == "0"
+
+    def test_a_value_containing_spaces_survives(self):
+        # Metadata starts at the FIRST metadata key, not the last: a metadata
+        # value can itself contain spaces.
+        row = (
+            "_id:20 name:device_name pkg:android value:Galaxy Z Flip6 "
+            "default:Galaxy Z Flip6 defaultSystemSet:true\n"
+        )
+        assert _parse(row)["device_name"] == "Galaxy Z Flip6"
+
+    def test_a_bare_value_is_unchanged(self):
+        row = "_id:14 name:package_verifier_enable pkg:android value:1\n"
+        assert _parse(row)["package_verifier_enable"] == "1"
+
+    def test_safe_setting_no_longer_raises_an_alert(self):
+        # send_action_app_error has safe_value "1"; before the fix the stored
+        # value was "1 isValuePreservedInRestore:true" and it was flagged.
+        artifact = Settings()
+        artifact.results = {}
+        artifact.parse(
+            HEADER + "_id:9 name:send_action_app_error pkg:android value:1 "
+            "isValuePreservedInRestore:true\n"
+        )
+        artifact.check_indicators()
+        assert artifact.alertstore.alerts == []


### PR DESCRIPTION
## The bug

`dumpsys settings` prints each row's own metadata after the value:

```
value:1 default:1 defaultSystemSet:true isValuePreservedInRestore:true
value:4 notPreservedInRestore
```

The inline strip in `Settings.parse()` matched one shape only —
`default:X defaultSystemSet:true|false` at end of line — so any other
combination stayed inside the parsed value. `check_indicators()` compares that
string to `safe_value` literally, so a dangerous setting sitting at its safe
value is reported as suspicious.

## The fix

Capture the value to end of line, then split the metadata off at the **first**
metadata key, not the last — a metadata value can itself contain spaces
(`value:Galaxy Z Flip6 default:Galaxy Z Flip6 defaultSystemSet:true`).

## Impact, measured on 30 bug reports (12 vendors, Android 10-16)

| | |
|---|---|
| settings rows | 80527, of which 35874 carry trailing metadata |
| rows keeping it inside the value | 19056, on 19 of 30 devices |
| dangerous-settings alerts before / after | **60 / 8** |
| removed / added | 52 / 0 (parsed key sets identical on all 30) |

The 8 survivors were confirmed against the raw rows. Most frequent false
positive: `accessibility_enabled`, reported as "enabled accessibility services"
on 15 of 30 devices whose value is `0`.

Only `check-bugreport` is affected — `AQFSettings` parses androidqf's
`settings_*.txt` as `key=value` and never reaches this parser.

Split-point safety: across those 35874 rows, no metadata key occurs twice after
`value:` and no remainder ends in anything other than a metadata token, so the
"value containing ` default:`" case does not occur. The value is now also
`.strip()`ed, which affects 10 rows on 7 devices (`value: [ UN UN UN ]`).

## Test plan

- [x] 6 new tests in `tests/android/test_artifact_settings_metadata.py`
- [x] `ruff check`, `ruff format --check`, `mypy`: clean
- [x] `pytest`: full suite green, and re-measured on the 30 bug reports above
