### PR TITLE
Stop persisting environment variables to config.yaml

### DIFF
--- a/src/mvt/common/config.py
+++ b/src/mvt/common/config.py
@@ -59,13 +59,16 @@ class MVTSettings(BaseSettings):
         dotenv_settings: PydanticBaseSettingsSource,
         file_secret_settings: PydanticBaseSettingsSource,
     ) -> Tuple[PydanticBaseSettingsSource, ...]:
-        yaml_source = YamlConfigSettingsSource(settings_cls, MVT_CONFIG_PATH)
         sources: Tuple[PydanticBaseSettingsSource, ...] = (
-            yaml_source,
+            YamlConfigSettingsSource(settings_cls, MVT_CONFIG_PATH),
             init_settings,
         )
-        # Always load env variables by default
-        sources = (env_settings,) + sources
+        # Load env variables only when asked to. initialise() constructs the
+        # settings once without them so that what gets written back to
+        # config.yaml never includes values taken from the environment.
+        # init_settings() returns the keyword arguments passed to the constructor.
+        if init_settings().get("load_env", True):
+            sources = (env_settings,) + sources
         return sources
 
     def save_settings(
@@ -92,7 +95,7 @@ class MVTSettings(BaseSettings):
 
         Afterwards we load the settings again, this time including the env variables.
         """
-        # Set invalid env prefix to avoid loading env variables.
+        # Construct the settings without env variables so they are not persisted.
         settings = cls(load_env=False)
         settings.save_settings()
 

--- a/tests/common/test_config.py
+++ b/tests/common/test_config.py
@@ -1,0 +1,30 @@
+# Mobile Verification Toolkit (MVT)
+# Copyright (c) 2021-2026 The MVT Authors.
+# Use of this software is governed by the MVT License 1.1 that can be found at
+#   https://license.mvt.re/1.1/
+
+import os
+
+import yaml
+
+from mvt.common import config
+from mvt.common.config import MVTSettings
+
+
+def test_env_variables_are_not_persisted_to_config_file(tmp_path, monkeypatch):
+    config_path = tmp_path / "config.yaml"
+    monkeypatch.setattr(config, "MVT_CONFIG_FOLDER", str(tmp_path))
+    monkeypatch.setattr(config, "MVT_CONFIG_PATH", str(config_path))
+    monkeypatch.setenv("MVT_NETWORK_ACCESS_ALLOWED", "false")
+    monkeypatch.setenv("MVT_IOS_BACKUP_PASSWORD", "env-only-password")
+
+    settings = MVTSettings.initialise()
+
+    assert os.path.isfile(config_path)
+    saved = yaml.safe_load(config_path.read_text()) or {}
+    assert "NETWORK_ACCESS_ALLOWED" not in saved
+    assert "IOS_BACKUP_PASSWORD" not in saved
+
+    # The environment must still apply to the settings in use.
+    assert settings.NETWORK_ACCESS_ALLOWED is False
+    assert settings.IOS_BACKUP_PASSWORD == "env-only-password"


### PR DESCRIPTION
Fixes #915.

## Problem

Any `MVT_*` environment variable set for a single run was written permanently into the user's `config.yaml` and read back on every later run. That includes `MVT_IOS_BACKUP_PASSWORD`, `MVT_ANDROID_BACKUP_PASSWORD` and `MVT_VT_API_KEY`, which ended up on disk in plaintext.

## Root cause

`MVTSettings.initialise()` constructs the settings once with `load_env=False`, saves the result to `config.yaml`, then constructs them again with the environment applied. The first instance is meant to exclude the environment so that nothing from it is ever persisted.

#716 replaced the `load_env` check in `settings_customise_sources` with an unconditional `sources = (env_settings,) + sources`, so `load_env` became dead code and the saved instance included environment values.

## Fix

Restore the guard so `env_settings` is only added when `load_env` is true. The issue proposed narrowing the `init_settings` annotation to `InitSettingsSource` and reading `init_kwargs`; mypy rejects that override as incompatible with the `BaseSettings` supertype, so the guard calls `init_settings()` instead, which returns the constructor keyword arguments through the source interface without narrowing the type. Runtime behaviour is identical to the pre-#716 code. The stale "invalid env prefix" comment in `initialise()` is replaced with one that describes what the code does.

## Test

`tests/common/test_config.py` points the config path at `tmp_path`, sets `MVT_NETWORK_ACCESS_ALLOWED` and `MVT_IOS_BACKUP_PASSWORD`, calls `MVTSettings.initialise()`, and asserts the written file contains neither key while the returned settings reflect both. The test fails on `main` with the exact leak from the issue and passes with the fix.

## Verification

- `make ruff`, `make mypy`: clean
- `make test-ci`: 439 passed, 1 skipped
- Manual repro from the issue with a temporary `HOME`: `config.yaml` stays `{}` with `MVT_NETWORK_ACCESS_ALLOWED=false` and `MVT_VT_API_KEY` set

## Note for users

Existing `config.yaml` files that already contain leaked values are not cleaned up by this change. Anyone who ran MVT with `MVT_*` variables set since 2026.4.28 should check the file and delete keys they did not intend to persist.
