### PR TITLE
Report an unreadable sysdiagnose archive instead of aborting silently

### DIFF
--- a/src/mvt/ios/cmd_check_sysdiagnose.py
+++ b/src/mvt/ios/cmd_check_sysdiagnose.py
@@ -7,7 +7,9 @@ import json
 import logging
 import os
 import shutil
+import sys
 import tarfile
+import zlib
 from pathlib import Path, PurePosixPath
 from tempfile import TemporaryDirectory
 from typing import Any, Optional
@@ -97,8 +99,19 @@ class CmdIOSCheckSysdiagnose(Command):
 
         self.log.info("Parsing sysdiagnose archive. This might take a while...")
         self.sysdiagnose_format = "tar"
-        self.sysdiagnose_archive = tarfile.open(self.target_path, "r:gz")
-        self._extract_sysdiagnose_archive()
+        try:
+            self.sysdiagnose_archive = tarfile.open(self.target_path, "r:gz")
+            self._extract_sysdiagnose_archive()
+        except (tarfile.ReadError, EOFError, zlib.error, OSError) as exc:
+            # A truncated archive ends in EOFError from gzip, which Click would
+            # otherwise report as a bare "Aborted!" with no reason.
+            self.log.critical(
+                "Unable to read the sysdiagnose archive %s: %s. "
+                "The file may be truncated or not a gzip-compressed tarball.",
+                self.target_path,
+                exc,
+            )
+            sys.exit(1)
 
     def _extract_sysdiagnose_archive(self) -> None:
         archive = self.sysdiagnose_archive

--- a/tests/test_check_ios_sysdiagnose.py
+++ b/tests/test_check_ios_sysdiagnose.py
@@ -1,4 +1,6 @@
 import logging
+import os
+import tarfile
 
 from click.testing import CliRunner
 
@@ -62,3 +64,29 @@ def test_check_sysdiagnose_warns_without_a_custom_module(tmp_path, caplog):
 
     assert result.exit_code == 0
     assert "No forensic sysdiagnose modules have been loaded" in caplog.text
+
+
+def _create_truncated_sysdiagnose_archive(tmp_path):
+    folder = tmp_path / "sysdiagnose_2026.01.01_00-00-00+0000_iPhone-OS_iPhone_23A000"
+    folder.mkdir()
+    (folder / "sysdiagnose.log").write_bytes(os.urandom(200_000))
+    archive = tmp_path / "sysdiagnose.tar.gz"
+    with tarfile.open(archive, "w:gz") as tar:
+        tar.add(folder, arcname=folder.name)
+    data = archive.read_bytes()
+    archive.write_bytes(data[: len(data) // 2])
+    return archive
+
+
+def test_check_sysdiagnose_reports_a_truncated_archive(tmp_path, caplog):
+    # A download that stopped halfway ends in EOFError from gzip, which Click
+    # would otherwise turn into a bare "Aborted!" with no reason given.
+    archive = _create_truncated_sysdiagnose_archive(tmp_path)
+
+    with caplog.at_level(logging.CRITICAL, logger="mvt"):
+        result = CliRunner().invoke(check_sysdiagnose, [str(archive)])
+
+    assert result.exit_code == 1
+    assert "Unable to read the sysdiagnose archive" in caplog.text
+    assert "truncated" in caplog.text
+    assert "Aborted!" not in result.output


### PR DESCRIPTION
A sysdiagnose tarball whose download stopped halfway ends in an `EOFError` from gzip while `check-sysdiagnose` extracts it. Click converts `EOFError` into `click.Abort`, so the command printed nothing but `Aborted!` and exited 1, even with `-v`. Reproduced on one archive: `gzip -t` reports `unexpected end of file`, `tar -tzf` lists 762 members before it stops.

The extraction now catches `tarfile.ReadError`, `EOFError`, `zlib.error` and `OSError`, logs the file and the reason at critical level with a hint that the file may be truncated or not a gzip tarball, and exits 1 the way `_create_storage` does on an unwritable output folder. A plain `.tar` handed to the gzip reader gets the same message instead of a traceback (it still does not open; that is a separate decision).

Test: builds a small sysdiagnose tarball from random bytes, keeps the first half, and asserts exit code 1, the critical message and no `Aborted!`.