### PR TITLE
Skip AppleDouble sidecars when listing a sysdiagnose

### DIFF
--- a/src/mvt/ios/cmd_check_sysdiagnose.py
+++ b/src/mvt/ios/cmd_check_sysdiagnose.py
@@ -86,6 +86,8 @@ class CmdIOSCheckSysdiagnose(Command):
             parent_path = Path(self.target_path).absolute().parent
             for root, _, filenames in os.walk(self.target_path):
                 for filename in filenames:
+                    if filename.startswith("._"):
+                        continue
                     absolute_path = os.path.join(root, filename)
                     file_path = os.path.relpath(absolute_path, parent_path)
                     self.sysdiagnose_files.append(file_path)
@@ -134,6 +136,11 @@ class CmdIOSCheckSysdiagnose(Command):
                 continue
 
             if not member_path.parts:
+                continue
+            # AppleDouble sidecars (._name) carry a file's extended attributes,
+            # not sysdiagnose content. Device archives hold hundreds of them;
+            # bsdtar hides them from listings, tarfile does not.
+            if member_path.name.startswith("._"):
                 continue
             archive_roots.add(member_path.parts[0])
 

--- a/tests/test_cmd_check_sysdiagnose.py
+++ b/tests/test_cmd_check_sysdiagnose.py
@@ -34,6 +34,7 @@ def _create_sysdiagnose_folder(tmp_path):
         "sysdiagnose_2024.01.02_03-04-05+0200.tar.gz", encoding="utf-8"
     )
     (folder / "report.ips").write_text('{"bug_type": 210}\nbody', encoding="utf-8")
+    (folder / "._artifact.txt").write_bytes(b"\x00\x05\x16\x07AppleDouble")
     return folder
 
 
@@ -67,6 +68,7 @@ def test_check_sysdiagnose_from_folder(tmp_path):
     assert _test_module(command).ips_files == [
         {"file_path": str(tmp_path / "sysdiagnose" / "report.ips"), "bug_type": 210}
     ]
+    assert "sysdiagnose/._artifact.txt" not in command.sysdiagnose_files
 
 
 def test_check_sysdiagnose_from_archive_closes_archive(tmp_path):
@@ -83,6 +85,7 @@ def test_check_sysdiagnose_from_archive_closes_archive(tmp_path):
         }
     ]
     assert command.sysdiagnose_archive is None
+    assert "sysdiagnose/._artifact.txt" not in command.sysdiagnose_files
 
 
 def test_archive_is_extracted_once_and_unsafe_members_are_skipped(tmp_path):


### PR DESCRIPTION
Device-generated sysdiagnose archives carry an AppleDouble `._<name>` entry beside every file that has extended attributes, an ACL or Finder info. bsdtar folds them back into the file on extraction and hides them from listings, so they are easy to miss, but `tarfile` returns them as ordinary members. `check-sysdiagnose` extracted them and passed them to every module, so anything globbing `*/logs/Foo/*.plist` also received `._com.apple.Foo.plist` and tried to parse an AppleDouble header, logging one warning per sidecar.

Sidecar counts on local archives: 134 (iOS 15.1), 15 (15.7), 205 (18.6), 545 and 1234 (26.x), so the number grows with each release.

This skips names starting with `._` on both the archive and the folder path, and adds a `._artifact.txt` to the test fixture so both paths are covered. Removing either guard fails the tests.

Live check: `mvt-ios check-sysdiagnose` with a module set that globs preference plists against an iOS 26.6.1 archive logged 22 "Unable to decode ... Invalid file" warnings before this change and none after; results were otherwise identical.
