### PR TITLE
Recommend pymobiledevice3 for iOS acquisition

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,107 +1,3 @@
-# Base image for building libraries
-# ---------------------------------
-FROM ubuntu:22.04 AS build-base
-
-ARG DEBIAN_FRONTEND=noninteractive
-
-# Install build tools and dependencies
-RUN apt-get update \
-  && apt-get install -y \
-  build-essential \
-  git \
-  autoconf \
-  automake \
-  libtool-bin \
-  pkg-config \
-  libcurl4-openssl-dev \
-  libusb-1.0-0-dev \
-  libssl-dev \
-  udev \
-  && rm -rf /var/lib/apt/lists/*
-
-
-# libplist
-# --------
-FROM build-base AS build-libplist
-
-# Build
-RUN git clone https://github.com/libimobiledevice/libplist && cd libplist \
-  && ./autogen.sh && make -j "$(nproc)" && make install DESTDIR=/build \
-  && cd .. && rm -rf libplist
-
-
-# libimobiledevice-glue
-# ---------------------
-FROM build-base AS build-libimobiledevice-glue
-
-# Install dependencies
-COPY --from=build-libplist /build /
-
-# Build
-RUN git clone https://github.com/libimobiledevice/libimobiledevice-glue && cd libimobiledevice-glue \
-  && ./autogen.sh && make -j "$(nproc)" && make install DESTDIR=/build \
-  && cd .. && rm -rf libimobiledevice-glue
-
-
-# libtatsu
-# --------
-FROM build-base AS build-libtatsu
-
-# Install dependencies
-COPY --from=build-libplist /build /
-
-# Build
-RUN git clone https://github.com/libimobiledevice/libtatsu && cd libtatsu \
-  && ./autogen.sh && make -j "$(nproc)" && make install DESTDIR=/build \
-  && cd .. && rm -rf libtatsu
-
-
-# libusbmuxd
-# ----------
-FROM build-base AS build-libusbmuxd
-
-# Install dependencies
-COPY --from=build-libplist /build /
-COPY --from=build-libimobiledevice-glue /build /
-
-# Build
-RUN git clone https://github.com/libimobiledevice/libusbmuxd && cd libusbmuxd \
-  && ./autogen.sh && make -j "$(nproc)" && make install DESTDIR=/build \
-  && cd .. && rm -rf libusbmuxd
-
-
-# libimobiledevice
-# ----------------
-FROM build-base AS build-libimobiledevice
-
-# Install dependencies
-COPY --from=build-libplist /build /
-COPY --from=build-libtatsu /build /
-COPY --from=build-libimobiledevice-glue /build /
-COPY --from=build-libusbmuxd /build /
-
-# Build
-RUN git clone https://github.com/libimobiledevice/libimobiledevice && cd libimobiledevice \
-  && ./autogen.sh --enable-debug && make -j "$(nproc)" && make install DESTDIR=/build \
-  && cd .. && rm -rf libimobiledevice
-
-
-# usbmuxd
-# -------
-FROM build-base AS build-usbmuxd
-
-# Install dependencies
-COPY --from=build-libplist /build /
-COPY --from=build-libimobiledevice-glue /build /
-COPY --from=build-libusbmuxd /build /
-COPY --from=build-libimobiledevice /build /
-
-# Build
-RUN git clone https://github.com/libimobiledevice/usbmuxd && cd usbmuxd \
-  && ./autogen.sh --sysconfdir=/etc --localstatedir=/var --runstatedir=/run && make -j "$(nproc)" && make install DESTDIR=/build \
-  && cd .. && rm -rf usbmuxd && mv /build/lib /build/usr/lib
-
-
 # Create main image
 FROM ubuntu:24.04 AS main
 COPY --from=ghcr.io/astral-sh/uv:0.11.8 /uv /uvx /usr/local/bin/
@@ -112,7 +8,7 @@ LABEL org.opencontainers.image.source="https://github.com/mvt-project/mvt"
 LABEL org.opencontainers.image.title="Mobile Verification Toolkit"
 LABEL org.opencontainers.image.description="MVT is a forensic tool to look for signs of infection in smartphone devices."
 LABEL org.opencontainers.image.licenses="MVT License 1.1"
-LABEL org.opencontainers.image.base.name=docker.io/library/ubuntu:22.04
+LABEL org.opencontainers.image.base.name=docker.io/library/ubuntu:24.04
 
 # Install runtime dependencies
 ARG DEBIAN_FRONTEND=noninteractive
@@ -125,7 +21,6 @@ RUN apt-get update \
   git \
   jq \
   less \
-  libcurl4 \
   libimage-exiftool-perl \
   libssl3 \
   libusb-1.0-0 \
@@ -136,18 +31,20 @@ RUN apt-get update \
   sqlite3 \
   tree \
   unzip \
-  xxd
-COPY --from=build-libplist /build /
-COPY --from=build-libimobiledevice-glue /build /
-COPY --from=build-libtatsu /build /
-COPY --from=build-libusbmuxd /build /
-COPY --from=build-libimobiledevice /build /
-COPY --from=build-usbmuxd /build /
+  xxd \
+  && rm -rf /var/lib/apt/lists/*
 
-# Install mvt using the locally checked out source
+# Install MVT and pymobiledevice3. Native build dependencies are needed on ARM64.
+ARG PYMOBILEDEVICE3_VERSION=11.12.4
 COPY . mvt/
-RUN uv pip install --system --break-system-packages --no-cache ./mvt \
-  && rm -rf mvt
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends build-essential python3-dev libssl-dev \
+  && uv pip install --system --break-system-packages --no-cache ./mvt "pymobiledevice3==${PYMOBILEDEVICE3_VERSION}" \
+  && apt-get purge -y --auto-remove build-essential python3-dev libssl-dev \
+  && rm -rf mvt /var/lib/apt/lists/* \
+  && pymobiledevice3 --help > /dev/null \
+  && pymobiledevice3 backup2 --help > /dev/null \
+  && mvt-ios --help > /dev/null
 
 # Installing ABE
 ADD --checksum=sha256:a20e07f8b2ea47620aff0267f230c3f1f495f097081fd709eec51cf2a2e11632 \

--- a/Dockerfile.ios
+++ b/Dockerfile.ios
@@ -1,110 +1,6 @@
-# Base image for building libraries
-# ---------------------------------
-FROM ubuntu:22.04 AS build-base
-
-ARG DEBIAN_FRONTEND=noninteractive
-
-# Install build tools and dependencies
-RUN apt-get update \
-  && apt-get install -y \
-  build-essential \
-  git \
-  autoconf \
-  automake \
-  libtool-bin \
-  pkg-config \
-  libcurl4-openssl-dev \
-  libusb-1.0-0-dev \
-  libssl-dev \
-  udev \
-  && rm -rf /var/lib/apt/lists/*
-
-
-# libplist
-# --------
-FROM build-base AS build-libplist
-
-# Build
-RUN git clone https://github.com/libimobiledevice/libplist && cd libplist \
-  && ./autogen.sh && make -j "$(nproc)" && make install DESTDIR=/build \
-  && cd .. && rm -rf libplist
-
-
-# libimobiledevice-glue
-# ---------------------
-FROM build-base AS build-libimobiledevice-glue
-
-# Install dependencies
-COPY --from=build-libplist /build /
-
-# Build
-RUN git clone https://github.com/libimobiledevice/libimobiledevice-glue && cd libimobiledevice-glue \
-  && ./autogen.sh && make -j "$(nproc)" && make install DESTDIR=/build \
-  && cd .. && rm -rf libimobiledevice-glue
-
-
-# libtatsu
-# --------
-FROM build-base AS build-libtatsu
-
-# Install dependencies
-COPY --from=build-libplist /build /
-
-# Build
-RUN git clone https://github.com/libimobiledevice/libtatsu && cd libtatsu \
-  && ./autogen.sh && make -j "$(nproc)" && make install DESTDIR=/build \
-  && cd .. && rm -rf libtatsu
-
-
-# libusbmuxd
-# ----------
-FROM build-base AS build-libusbmuxd
-
-# Install dependencies
-COPY --from=build-libplist /build /
-COPY --from=build-libimobiledevice-glue /build /
-
-# Build
-RUN git clone https://github.com/libimobiledevice/libusbmuxd && cd libusbmuxd \
-  && ./autogen.sh && make -j "$(nproc)" && make install DESTDIR=/build \
-  && cd .. && rm -rf libusbmuxd
-
-
-# libimobiledevice
-# ----------------
-FROM build-base AS build-libimobiledevice
-
-# Install dependencies
-COPY --from=build-libplist /build /
-COPY --from=build-libtatsu /build /
-COPY --from=build-libimobiledevice-glue /build /
-COPY --from=build-libusbmuxd /build /
-
-# Build
-RUN git clone https://github.com/libimobiledevice/libimobiledevice && cd libimobiledevice \
-  && ./autogen.sh --enable-debug && make -j "$(nproc)" && make install DESTDIR=/build \
-  && cd .. && rm -rf libimobiledevice
-
-
-# usbmuxd
-# -------
-FROM build-base AS build-usbmuxd
-
-# Install dependencies
-COPY --from=build-libplist /build /
-COPY --from=build-libimobiledevice-glue /build /
-COPY --from=build-libusbmuxd /build /
-COPY --from=build-libimobiledevice /build /
-
-# Build
-RUN git clone https://github.com/libimobiledevice/usbmuxd && cd usbmuxd \
-  && ./autogen.sh --sysconfdir=/etc --localstatedir=/var --runstatedir=/run && make -j "$(nproc)" && make install DESTDIR=/build \
-  && cd .. && rm -rf usbmuxd && mv /build/lib /build/usr/lib
-
-
 # Main image
 # ----------
-FROM python:3.10.14-alpine3.20 AS main
+FROM ubuntu:24.04 AS main
 COPY --from=ghcr.io/astral-sh/uv:0.11.8 /uv /uvx /usr/local/bin/
 
 LABEL org.opencontainers.image.url="https://mvt.re"
@@ -113,26 +9,30 @@ LABEL org.opencontainers.image.source="https://github.com/mvt-project/mvt"
 LABEL org.opencontainers.image.title="Mobile Verification Toolkit (iOS)"
 LABEL org.opencontainers.image.description="MVT is a forensic tool to look for signs of infection in smartphone devices."
 LABEL org.opencontainers.image.licenses="MVT License 1.1"
-LABEL org.opencontainers.image.base.name=docker.io/library/python:3.10.14-alpine3.20
+LABEL org.opencontainers.image.base.name=docker.io/library/ubuntu:24.04
 
 # Install runtime dependencies
-RUN apk add --no-cache \
-  gcompat \
-  libcurl \
+ARG DEBIAN_FRONTEND=noninteractive
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends \
+  ca-certificates \
+  git \
   libssl3 \
-  libusb \
-  sqlite
-COPY --from=build-libplist /build /
-COPY --from=build-libimobiledevice-glue /build /
-COPY --from=build-libtatsu /build /
-COPY --from=build-libusbmuxd /build /
-COPY --from=build-libimobiledevice /build /
-COPY --from=build-usbmuxd /build /
+  libusb-1.0-0 \
+  python3 \
+  sqlite3 \
+  && rm -rf /var/lib/apt/lists/*
 
-# Install mvt using the locally checked out source
-COPY ./ mvt
-RUN apk add --no-cache --virtual .build-deps git gcc musl-dev \
-  && uv pip install --system --no-cache ./mvt \
-  && apk del .build-deps git gcc musl-dev && rm -rf ./mvt
+# Install MVT and pymobiledevice3. Native build dependencies are needed on ARM64.
+ARG PYMOBILEDEVICE3_VERSION=11.12.4
+COPY . mvt/
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends build-essential python3-dev libssl-dev \
+  && uv pip install --system --break-system-packages --no-cache ./mvt "pymobiledevice3==${PYMOBILEDEVICE3_VERSION}" \
+  && apt-get purge -y --auto-remove build-essential python3-dev libssl-dev \
+  && rm -rf mvt /var/lib/apt/lists/* \
+  && pymobiledevice3 --help > /dev/null \
+  && pymobiledevice3 backup2 --help > /dev/null \
+  && mvt-ios --help > /dev/null
 
 ENTRYPOINT [ "/usr/local/bin/mvt-ios" ]

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -1,6 +1,6 @@
 Using Docker simplifies running MVT with its dependencies readily installed. Note that this requires a Linux host, as Docker for Windows and Mac [doesn't support passing through USB devices](https://docs.docker.com/desktop/faqs/#can-i-pass-through-a-usb-device-to-a-container).
 
-For iOS acquisition, we recommend [installing pymobiledevice3](ios/install.md) on the host and [creating a backup](ios/backup/pymobiledevice3.md) before analyzing it with MVT. The Docker images currently include libimobiledevice, not pymobiledevice3.
+The main and iOS Docker images include pymobiledevice3 for [creating iOS backups](ios/backup/pymobiledevice3.md). You do not need to install it separately on the host. Older image tags may still include libimobiledevice instead; build from the updated source if pymobiledevice3 is unavailable.
 
 Install Docker following the [official documentation](https://docs.docker.com/get-docker/).
 
@@ -39,12 +39,31 @@ If a prompt is spawned successfully, you can close it with `exit`.
 
 On the Linux host, install and start [usbmuxd](https://github.com/libimobiledevice/usbmuxd), then connect and unlock the iOS device. The daemon exposes the device through the `/var/run/usbmuxd` socket.
 
-Bind that socket into the container to let MVT communicate with the device:
+Bind that socket into the container to let pymobiledevice3 communicate with the device. Also mount a local directory so acquired backups persist after the container exits:
 
 ```bash
-docker run -it \
+mkdir -p "$PWD/cases"
+docker run --rm -it \
     --mount type=bind,source=/var/run/usbmuxd,target=/var/run/usbmuxd \
+    --mount type=bind,source="$PWD/cases",target=/home/cases \
     ghcr.io/mvt-project/mvt
+```
+
+Inside the container, verify connectivity:
+
+```bash
+pymobiledevice3 lockdown info
+```
+
+Accept the trust prompt on the unlocked device if requested. Then follow the [backup instructions](ios/backup/pymobiledevice3.md), using a destination under `/home/cases`, such as `/home/cases/backup`.
+
+The iOS-only image defaults to running `mvt-ios`. To use pymobiledevice3 instead, override its entrypoint:
+
+```bash
+docker run --rm -it \
+    --mount type=bind,source=/var/run/usbmuxd,target=/var/run/usbmuxd \
+    --entrypoint pymobiledevice3 \
+    ghcr.io/mvt-project/mvt:latest-ios lockdown info
 ```
 
 If you built the image from source, replace `ghcr.io/mvt-project/mvt` with `mvt`. 

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -1,4 +1,6 @@
-Using Docker simplifies having all the required dependencies and tools (including most recent versions of [libimobiledevice](https://libimobiledevice.org)) readily installed. Note that this requires a Linux host, as Docker for Windows and Mac [doesn't support passing through USB devices](https://docs.docker.com/desktop/faqs/#can-i-pass-through-a-usb-device-to-a-container).
+Using Docker simplifies running MVT with its dependencies readily installed. Note that this requires a Linux host, as Docker for Windows and Mac [doesn't support passing through USB devices](https://docs.docker.com/desktop/faqs/#can-i-pass-through-a-usb-device-to-a-container).
+
+For iOS acquisition, we recommend [installing pymobiledevice3](ios/install.md) on the host and [creating a backup](ios/backup/pymobiledevice3.md) before analyzing it with MVT. The Docker images currently include libimobiledevice, not pymobiledevice3.
 
 Install Docker following the [official documentation](https://docs.docker.com/get-docker/).
 

--- a/docs/ios/backup/libimobiledevice.md
+++ b/docs/ios/backup/libimobiledevice.md
@@ -1,19 +1,3 @@
 # Backup with libimobiledevice
 
-If you have correctly [installed libimobiledevice](../install.md) you can easily generate an iTunes backup using the `idevicebackup2` tool included in the suite. First, you might want to ensure that backup encryption is enabled (**note: encrypted backup contain more data than unencrypted backups**):
-
-```bash
-idevicebackup2 -i encryption on
-```
-
-Note that if a backup password was previously set on this device, you might need to use the same or change it. You can try changing password using `idevicebackup2 -i changepw`, or by turning off encryption (`idevicebackup2 -i encryption off`) and turning it back on again.
-
-If you are not able to recover or change the password, you should try to disable encryption and obtain an unencrypted backup.
-
-If all else fails, as a *last resort* you can try resetting the password by [resetting all the settings through the iPhone's Settings app](https://support.apple.com/en-us/HT205220), via `Settings » General » Reset » Reset All Settings`.  Note that resetting the settings through the iPhone's Settings app will wipe some of the files that contain useful forensic traces, so try the options explained above first.
-
-Once ready, you can proceed performing the backup:
-
-```bash
-idevicebackup2 backup --full /path/to/backup/
-```
+We now recommend pymobiledevice3 for iOS backups. See [Backup with pymobiledevice3](pymobiledevice3.md) for the current instructions.

--- a/docs/ios/backup/pymobiledevice3.md
+++ b/docs/ios/backup/pymobiledevice3.md
@@ -1,0 +1,37 @@
+# Backup with pymobiledevice3
+
+After [installing pymobiledevice3](../install.md) and pairing your device, you can generate an iTunes-compatible backup using its `backup2` commands.
+
+## Enable backup encryption
+
+We recommend encrypted backups because they contain more data than unencrypted backups. If encryption is not already enabled, enable it with:
+
+```bash
+pymobiledevice3 backup2 encryption on 'YOUR_BACKUP_PASSWORD'
+```
+
+Replace `YOUR_BACKUP_PASSWORD` with a strong password and keep it safe: you will need it to decrypt the backup for analysis. Passwords supplied on the command line may be saved in shell history or visible to other processes.
+
+If a backup password was previously set, use that password. To change a known password:
+
+```bash
+pymobiledevice3 backup2 change-password 'CURRENT_PASSWORD' 'NEW_PASSWORD'
+```
+
+You can also disable encryption with `pymobiledevice3 backup2 encryption off 'CURRENT_PASSWORD'` and then enable it again. Disabling encryption requires the current password; it is not a way to bypass an unknown password.
+
+!!! warning
+    If you cannot recover the password, resetting it through [Reset All Settings in the iPhone's Settings app](https://support.apple.com/en-us/HT205220) should be a last resort. Resetting settings can remove files containing useful forensic traces.
+
+## Create a backup
+
+Choose a new destination directory to avoid overwriting an earlier acquisition:
+
+```bash
+mkdir -p /path/to/backup/
+pymobiledevice3 backup2 backup --full /path/to/backup/
+```
+
+The backup is saved in a subdirectory named after the device's UDID, such as `/path/to/backup/udid/`. Follow [Check a Backup with mvt-ios](check.md) to decrypt and analyze that directory.
+
+For additional options, see the [pymobiledevice3 backup2 reference](https://doronz88.github.io/pymobiledevice3/cli/backup2/).

--- a/docs/ios/install.md
+++ b/docs/ios/install.md
@@ -1,55 +1,44 @@
-# Install libimobiledevice
+# Install pymobiledevice3
 
-Before proceeding with doing any acquisition of iOS devices we recommend installing [libimobiledevice](https://libimobiledevice.org/) utilities. These utilities will become useful when extracting crash logs and generating iTunes backups. Because the utilities and its libraries are subject to frequent changes in response to new versions of iOS, you might want to consider compiling libimobiledevice utilities from sources. Otherwise, if available, you can try installing packages available in your distribution:
+Before acquiring data from an iOS device, we recommend installing [pymobiledevice3](https://github.com/doronz88/pymobiledevice3). It provides command-line tools for generating iTunes-compatible backups and extracting crash logs.
 
-```bash
-sudo apt install libimobiledevice-utils
-```
+## Installation
 
-On Mac, you can try installing it from brew:
+Install `pipx` following the [MVT installation instructions](../install.md), then run:
 
 ```bash
-brew install --HEAD libimobiledevice
+pipx install pymobiledevice3
 ```
 
-If you have a reasonably recent version of libimobiledevice in your package manager, it might work straight out of the box. Try connecting your iOS device to your computer via USB and run:
+To update an existing installation:
 
 ```bash
-ideviceinfo
+pipx upgrade pymobiledevice3
 ```
 
-If you encounter unexpected issues, uninstall the packages and try compiling libimobiledevcice from sources.
-
-## Compile libimobiledevice from sources
-
-!!! warning
-    The following instructions are a best effort. The installation from source requires several steps, and it is likely some have been forgotten here and that won't work for you. You will likely need to fiddle around a bit before getting this right.
-
-Make sure you have uninstalled all the libimobiledevice tools from your package manage:
+On Linux, you also need `usbmuxd` to communicate with devices over USB. On Debian and Ubuntu, install it with:
 
 ```bash
-sudo apt remove --purge libimobiledevice-utils libimobiledevice-dev libimobiledevice6 libplist-dev libplist3 libusbmuxd-dev libusbmuxd-tools libusbmuxd4 libusbmuxd6 usbmuxd
+sudo apt install usbmuxd
 ```
 
-Firstly you need to install [libplist](https://github.com/libimobiledevice/libplist). Then you can install [libusbmuxd](https://github.com/libimobiledevice/libusbmuxd).
+macOS includes the required USB device service. For other platforms and additional requirements, see the [pymobiledevice3 installation documentation](https://doronz88.github.io/pymobiledevice3/installation/).
 
-Now you should be able to to download and install the actual suite of tools at [https://github.com/libimobiledevice/libimobiledevice](https://github.com/libimobiledevice/libimobiledevice).
+## Verify connectivity
 
-You can now also build and install [usbmuxd](https://github.com/libimobiledevice/usbmuxd).
-
-## Making sure everything works fine.
-
-Once the idevice tools are available you can check if everything works fine by connecting your iOS device and running:
+Connect the iOS device to your computer with a USB cable and unlock it. Accept the **Trust This Computer** prompt and enter the device passcode if requested. Then run:
 
 ```bash
-ideviceinfo
+pymobiledevice3 usbmux list
+pymobiledevice3 lockdown info
 ```
 
-This should show many details on the connected iOS device. If you are connecting the device to your laptop for the first time, it will require to unlock and enter the PIN code on the mobile device. If it complains that no device is connected and the mobile device is indeed plugged in through the USB cable, you might need to do this first, although typically the pairing is automatically done when connecting the device:
+These commands should list the connected device and display its details. If pairing is needed, run:
 
 ```bash
-sudo usbmuxd -f -v
-idevicepair pair
+pymobiledevice3 lockdown pair
 ```
 
-Again, it will ask to unlock the phone and enter the PIN code. 
+If no device is found, check the USB connection, make sure the device is unlocked, and, on Linux, check that `usbmuxd` is running. See the [upstream troubleshooting guide](https://doronz88.github.io/pymobiledevice3/guides/troubleshooting/) for further help.
+
+Once connected, follow the [backup instructions](backup/pymobiledevice3.md).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -5,6 +5,7 @@ copyright: Copyright &copy; 2021-2023 MVT Project Developers
 site_description: Mobile Verification Toolkit Documentation
 not_in_nav: |
     android/adb.md
+    ios/backup/libimobiledevice.md
 markdown_extensions:
     - attr_list
     - admonition
@@ -34,10 +35,10 @@ nav:
     - Using Docker: "docker.md"
     - MVT for iOS:
         - iOS Forensic Methodology: "ios/methodology.md"
-        - Install libimobiledevice: "ios/install.md"
+        - Install pymobiledevice3: "ios/install.md"
         - Check an iTunes Backup:
             - Backup with iTunes app: "ios/backup/itunes.md"
-            - Backup with libimobiledevice: "ios/backup/libimobiledevice.md"
+            - Backup with pymobiledevice3: "ios/backup/pymobiledevice3.md"
             - Check a Backup with mvt-ios: "ios/backup/check.md"
         - Check a Filesystem Dump:
             - Dumping the filesystem: "ios/filesystem/dump.md"


### PR DESCRIPTION
## Summary
- Recommend pymobiledevice3 for iOS setup and encrypted backup acquisition, with updated installation, pairing, and backup commands.
- Update documentation navigation and retain the old backup page as a link to the new guide.
- Clarify that Docker images still include libimobiledevice and recommend pymobiledevice3 acquisition on the host.

## Validation
- Verified replacement commands against upstream pymobiledevice3 documentation.
- `uv run --isolated --only-group docs mkdocs build --strict --site-dir /tmp/mvt-docs-pymobiledevice3`
- `git diff --check`